### PR TITLE
fix: stabilize emulator location override fetch and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,8 @@ You can create a file `src/pkjs/dev-config.js` to set values for Clay keys (for 
 ```javascript
 var owmApiKey = 'abc123';
 module.exports.owmApiKey = owmApiKey;
+module.exports.location = 'New York, NY';
+module.exports.forceFetchOnBoot = true;
 ```
+
+When `forceFetchOnBoot` is `true`, PKJS clears the saved `lastFetchSuccess` value on startup so weather is fetched immediately instead of waiting for the normal refresh window.

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -121,10 +121,19 @@ function clayTryDevConfig() {
         var persistClay = getClaySettings();
         for (var prop in devConfig) {
             if (Object.prototype.hasOwnProperty.call(devConfig, prop)) {
+                if (prop === 'forceFetchOnBoot') {
+                    continue;
+                }
                 persistClay[prop] = devConfig[prop];
                 console.log('Found dev setting: ' + prop + '=' + devConfig[prop]);
             }
         }
+
+        if (devConfig.forceFetchOnBoot === true) {
+            console.log('Found dev setting: forceFetchOnBoot=true (clearing lastFetchSuccess)');
+            localStorage.removeItem('lastFetchSuccess');
+        }
+
         localStorage.setItem('clay-settings', JSON.stringify(persistClay));
     }
     catch (ex) {


### PR DESCRIPTION
- tighten location override parsing and reverse-geocode handling so text queries are handled correctly and missing address payloads do not crash PKJS.
- add `forceFetchOnBoot` support in `src/pkjs/dev-config.js` processing so emulator boots can force an immediate weather fetch without opening settings.
- document dev-config usage with an example location (`New York, NY`) and improve geocode log output readability.
ref: https://github.com/mattrossman/forecaswatch2/issues/59