### PR TITLE
fix: reduce startup heap usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@
 # Phone IP used by `mise install-phone`
 IP=192.168.1.100
 
+# Enable extra heap debug logs in Pebble C builds
+# ENABLE_MEMORY_LOGGING=1
+
 
 ##################################
 # Supabase environment variables #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,8 @@ If you use Supabase GitHub sync/branching, Supabase can auto-apply migrations an
 
 `mise build` and `mise build release` automatically generate `package.json` from the template/profile before building.
 
+If you want the extra Pebble heap debug logs, set `ENABLE_MEMORY_LOGGING=1` in your `.env` before building or installing. This is independent of the dev/release package profile.
+
 Release notification copy (optional “what’s new” toast on upgrade) lives in `release-notifications.json`, keyed by the exact `version` string from the template (e.g. `"1.26.0"`). `prepare-package` copies only the entry for the version being built into `package.json`; versions with no key ship without a notification.
 
 If you want to regenerate `package.json` without building:

--- a/src/c/layers/battery_layer.c
+++ b/src/c/layers/battery_layer.c
@@ -11,7 +11,7 @@
 
 static Layer *s_battery_layer;
 static GBitmap *s_battery_power_bitmap;
-static GColor *s_battery_palette;
+static GColor s_battery_palette[2];
 
 static void battery_state_handler(BatteryChargeState charge) {
     battery_layer_refresh();
@@ -77,18 +77,26 @@ static void battery_update_proc(Layer *layer, GContext *ctx) {
 }
 
 void battery_layer_create(Layer* parent_layer, GRect frame) {
-    s_battery_layer = layer_create(frame);
-    s_battery_power_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_BATTERY_CHARGING);
+    MemoryHeapProbe probe = MEMORY_HEAP_PROBE_START("battery_layer_create");
 
-    s_battery_palette = malloc(2 * sizeof(GColor));
+    s_battery_layer = layer_create(frame);
+    MEMORY_HEAP_PROBE_SAMPLE("after_layer_create", &probe);
+
+    s_battery_power_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_BATTERY_CHARGING);
+    MEMORY_HEAP_PROBE_SAMPLE("after_bitmap_create", &probe);
+
     s_battery_palette[0] = GColorWhite;
     s_battery_palette[1] = GColorClear;
     gbitmap_set_palette(s_battery_power_bitmap, s_battery_palette, false);
+    MEMORY_HEAP_PROBE_SAMPLE("after_palette_set", &probe);
 
     layer_set_update_proc(s_battery_layer, battery_update_proc);
     battery_state_service_subscribe(battery_state_handler);
+    MEMORY_HEAP_PROBE_SAMPLE("after_battery_subscribe", &probe);
     layer_add_child(parent_layer, s_battery_layer);
+    MEMORY_HEAP_PROBE_SAMPLE("after_layer_add_child", &probe);
     MEMORY_LOG_HEAP("after_battery_layer_create");
+    MEMORY_HEAP_PROBE_LOG_MIN(&probe);
 }
 
 void battery_layer_refresh() {
@@ -98,7 +106,6 @@ void battery_layer_refresh() {
 void battery_layer_destroy() {
     MEMORY_LOG_HEAP("battery_layer_destroy:before");
     battery_state_service_unsubscribe();
-    free(s_battery_palette);
     gbitmap_destroy(s_battery_power_bitmap);
     layer_destroy(s_battery_layer);
     MEMORY_LOG_HEAP("battery_layer_destroy:after");

--- a/src/c/layers/calendar_layer.c
+++ b/src/c/layers/calendar_layer.c
@@ -8,7 +8,13 @@
 #define FONT_OFFSET 5
 
 static Layer *s_calendar_layer;
-static TextLayer *s_calendar_text_layers[NUM_WEEKS * DAYS_PER_WEEK];
+
+static GRect calendar_cell_rect(GRect bounds, int i) {
+    float box_w = (float) bounds.size.w / DAYS_PER_WEEK;
+    float box_h = (float) bounds.size.h / NUM_WEEKS;
+    return GRect((i % DAYS_PER_WEEK) * box_w, (i / DAYS_PER_WEEK) * box_h - FONT_OFFSET,
+                 box_w, box_h + FONT_OFFSET);
+}
 
 /* Copy struct tm out of localtime's static buffer — see localtime(3). */
 static struct tm relative_tm(int days_from_today)
@@ -106,26 +112,27 @@ static void calendar_update_proc(Layer *layer, GContext *ctx) {
     graphics_fill_rect(ctx,
         GRect((i_today % DAYS_PER_WEEK) * box_w, (i_today / DAYS_PER_WEEK) * box_h,
         box_w, box_h), 1, GCornersAll);
+
+    for (int i = 0; i < NUM_WEEKS * DAYS_PER_WEEK; ++i) {
+        struct tm t = relative_tm(i - i_today);
+        bool highlight_holiday = (config_highlight_holidays() && is_us_federal_holiday(&t));
+        bool highlight_sunday = (config_highlight_sundays() && t.tm_wday == 0);
+        bool highlight_saturday = (config_highlight_saturdays() && t.tm_wday == 6);
+        bool bold = (i == i_today) || highlight_holiday || highlight_sunday || highlight_saturday;
+        GColor text_color = (i == i_today) ? gcolor_legible_over(today_color())
+                                           : PBL_IF_COLOR_ELSE(date_color(&t), GColorWhite);
+        char buffer[4];
+
+        graphics_context_set_text_color(ctx, text_color);
+        graphics_draw_text(ctx,
+            (snprintf(buffer, sizeof(buffer), "%d", t.tm_mday), buffer),
+            fonts_get_system_font(bold ? FONT_KEY_GOTHIC_18_BOLD : FONT_KEY_GOTHIC_18),
+            calendar_cell_rect(bounds, i), GTextOverflowModeFill, GTextAlignmentCenter, NULL);
+    }
 }
 
 void calendar_layer_create(Layer* parent_layer, GRect frame) {
     s_calendar_layer = layer_create(frame);
-    GRect bounds = layer_get_bounds(s_calendar_layer);
-    int w = bounds.size.w;
-    int h = bounds.size.h;
-    float box_w = (float) w / DAYS_PER_WEEK;
-    float box_h = (float) h / NUM_WEEKS;
-
-    for (int i = 0; i < NUM_WEEKS * DAYS_PER_WEEK; ++i) {
-        // Place a text box in that space
-        TextLayer *s_box_text_layer = text_layer_create(
-            GRect((i % DAYS_PER_WEEK) * box_w, (i / DAYS_PER_WEEK) * box_h - FONT_OFFSET,
-                  box_w, box_h + FONT_OFFSET));
-        text_layer_set_background_color(s_box_text_layer, GColorClear);
-        text_layer_set_text_alignment(s_box_text_layer, GTextAlignmentCenter);
-        s_calendar_text_layers[i] = s_box_text_layer;
-        layer_add_child(s_calendar_layer, text_layer_get_layer(s_box_text_layer));
-    }
     layer_set_update_proc(s_calendar_layer, calendar_update_proc);
     calendar_layer_refresh();
     layer_add_child(parent_layer, s_calendar_layer);
@@ -134,46 +141,12 @@ void calendar_layer_create(Layer* parent_layer, GRect frame) {
 
 
 void calendar_layer_refresh() {
-    static char s_calendar_box_buffers[NUM_WEEKS * DAYS_PER_WEEK][4];
     // Request redraw (of today's highlight)
     layer_mark_dirty(s_calendar_layer);
-
-    // Calculate which box holds today's date
-    const int i_today = config_n_today();
-
-    // Fill each box with an appropriate relative day number
-    for (int i = 0; i < NUM_WEEKS * DAYS_PER_WEEK; ++i) {
-        char *buffer = s_calendar_box_buffers[i];
-        struct tm t = relative_tm(i - i_today);
-
-        // Set the text color
-        if (i == i_today) {
-            GColor text_color = gcolor_legible_over(today_color());
-            text_layer_set_text_color(s_calendar_text_layers[i], text_color);
-        }
-        else {
-            GColor text_color = PBL_IF_COLOR_ELSE(date_color(&t), GColorWhite);
-            text_layer_set_text_color(s_calendar_text_layers[i], text_color);
-        }
-
-        // Use bold font for today, and holidays/weekends if colored
-        bool highlight_holiday = (config_highlight_holidays() && is_us_federal_holiday(&t));
-        bool highlight_sunday = (config_highlight_sundays() && t.tm_wday == 0);
-        bool highlight_saturday = (config_highlight_saturdays() && t.tm_wday == 6);
-        bool bold = (i == i_today) || highlight_holiday || highlight_sunday || highlight_saturday;
-        text_layer_set_font(s_calendar_text_layers[i],
-            fonts_get_system_font(bold ? FONT_KEY_GOTHIC_18_BOLD : FONT_KEY_GOTHIC_18));
-
-        snprintf(buffer, 4, "%d", t.tm_mday);
-        text_layer_set_text(s_calendar_text_layers[i], buffer);
-    }
 }
 
 void calendar_layer_destroy() {
     MEMORY_LOG_HEAP("calendar_layer_destroy:before");
-    for (int i = 0; i < NUM_WEEKS * DAYS_PER_WEEK; ++i) {
-        text_layer_destroy(s_calendar_text_layers[i]);
-    }
     layer_destroy(s_calendar_layer);
     MEMORY_LOG_HEAP("calendar_layer_destroy:after");
 }

--- a/src/c/layers/calendar_status_layer.c
+++ b/src/c/layers/calendar_status_layer.c
@@ -16,23 +16,36 @@ static TextLayer *s_calendar_month_layer;
 static GBitmap *s_mute_bitmap;
 static GBitmap *s_bt_bitmap;
 static GBitmap *s_bt_disconnect_bitmap;
-static BitmapLayer *s_mute_bitmap_layer;
-static BitmapLayer *s_bt_bitmap_layer;
-static BitmapLayer *s_bt_disconnect_bitmap_layer;
 static GColor *s_bt_palette;
 static GColor *s_bt_disconnect_palette;
 static GColor *s_mute_palette;
 
+static void draw_bitmap(GContext *ctx, GBitmap *bitmap, GRect frame) {
+    graphics_context_set_compositing_mode(ctx, GCompOpSet);
+    graphics_draw_bitmap_in_rect(ctx, bitmap, frame);
+    graphics_context_set_compositing_mode(ctx, GCompOpAssign);
+}
 
-static void bitmap_layer_move_frame(BitmapLayer *bitmap_layer, GRect frame) {
-    layer_set_frame(bitmap_layer_get_layer(bitmap_layer), frame);
+static void calendar_status_update_proc(Layer *layer, GContext *ctx) {
+    bool show_qt = show_qt_icon();
+    bool connected = connection_service_peek_pebble_app_connection();
+    int icon_x = show_qt ? ICON_SLOT_2.origin.x : ICON_SLOT_1.origin.x;
+
+    if (show_qt) {
+        draw_bitmap(ctx, s_mute_bitmap, ICON_SLOT_1);
+    }
+
+    if (connected && g_config->show_bt) {
+        draw_bitmap(ctx, s_bt_bitmap, GRect(icon_x, 0, 10, 10));
+    } else if (!connected && g_config->show_bt_disconnect) {
+        draw_bitmap(ctx, s_bt_disconnect_bitmap, GRect(icon_x, 0, 10, 10));
+    }
 }
 
 void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
     s_calendar_status_layer = layer_create(frame);
     GRect bounds = layer_get_bounds(s_calendar_status_layer);
     int w = bounds.size.w;
-    int h = bounds.size.h;
 
     // Set up icons
     s_mute_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_MUTE);
@@ -55,19 +68,6 @@ void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
     s_mute_palette[1] = GColorClear;
     gbitmap_set_palette(s_mute_bitmap, s_mute_palette, false);
 
-    s_mute_bitmap_layer = bitmap_layer_create(ICON_SLOT_1);
-    bitmap_layer_set_compositing_mode(s_mute_bitmap_layer, GCompOpSet);
-    bitmap_layer_set_bitmap(s_mute_bitmap_layer, s_mute_bitmap);
-
-    s_bt_bitmap_layer = bitmap_layer_create(ICON_SLOT_2);
-    bitmap_layer_set_compositing_mode(s_bt_bitmap_layer, GCompOpSet);
-    bitmap_layer_set_bitmap(s_bt_bitmap_layer, s_bt_bitmap);
-
-    s_bt_disconnect_bitmap_layer = bitmap_layer_create(ICON_SLOT_2);
-    bitmap_layer_set_compositing_mode(s_bt_disconnect_bitmap_layer, GCompOpSet);
-    bitmap_layer_set_bitmap(s_bt_disconnect_bitmap_layer, s_bt_disconnect_bitmap);
-
-
     // Set up month text layer
     s_calendar_month_layer = text_layer_create(GRect(0, -MONTH_FONT_OFFSET, w, 25));
     text_layer_set_background_color(s_calendar_month_layer, GColorClear);
@@ -81,20 +81,16 @@ void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
     });
 
     calendar_status_layer_refresh();
-    layer_add_child(s_calendar_status_layer, bitmap_layer_get_layer(s_mute_bitmap_layer));
-    layer_add_child(s_calendar_status_layer, bitmap_layer_get_layer(s_bt_bitmap_layer));
-    layer_add_child(s_calendar_status_layer, bitmap_layer_get_layer(s_bt_disconnect_bitmap_layer));
     layer_add_child(s_calendar_status_layer, text_layer_get_layer(s_calendar_month_layer));
+    layer_set_update_proc(s_calendar_status_layer, calendar_status_update_proc);
     battery_layer_create(s_calendar_status_layer, GRect(w - BATTERY_W - PADDING, 1, BATTERY_W, BATTERY_H));
     layer_add_child(parent_layer, s_calendar_status_layer);
     MEMORY_LOG_HEAP("after_calendar_status_layer_create");
 }
 
 void bluetooth_icons_refresh(bool connected) {
-    bool show_bt = connected && g_config->show_bt;
-    bool show_bt_disconnect = !connected && g_config->show_bt_disconnect;
-    layer_set_hidden(bitmap_layer_get_layer(s_bt_bitmap_layer), !show_bt);
-    layer_set_hidden(bitmap_layer_get_layer(s_bt_disconnect_bitmap_layer), !show_bt_disconnect);
+    (void)connected;
+    layer_mark_dirty(s_calendar_status_layer);
 }
 
 void bluetooth_callback(bool connected) {
@@ -108,10 +104,7 @@ bool show_qt_icon() {
 }
 
 void status_icons_refresh() {
-    bool show_qt = show_qt_icon();
-    layer_set_hidden(bitmap_layer_get_layer(s_mute_bitmap_layer), !show_qt);
-    bitmap_layer_move_frame(s_bt_bitmap_layer, show_qt ? ICON_SLOT_2 : ICON_SLOT_1);
-    bitmap_layer_move_frame(s_bt_disconnect_bitmap_layer, show_qt ? ICON_SLOT_2 : ICON_SLOT_1);
+    layer_mark_dirty(s_calendar_status_layer);
 
     // Ensure bt icons are correct at start
     bluetooth_icons_refresh(connection_service_peek_pebble_app_connection());
@@ -136,9 +129,6 @@ void calendar_status_layer_destroy() {
     gbitmap_destroy(s_mute_bitmap);
     gbitmap_destroy(s_bt_bitmap);
     gbitmap_destroy(s_bt_disconnect_bitmap);
-    bitmap_layer_destroy(s_mute_bitmap_layer);
-    bitmap_layer_destroy(s_bt_bitmap_layer);
-    bitmap_layer_destroy(s_bt_disconnect_bitmap_layer);
     layer_destroy(s_calendar_status_layer);
     MEMORY_LOG_HEAP("calendar_status_layer_destroy:after");
 }

--- a/src/c/layers/calendar_status_layer.c
+++ b/src/c/layers/calendar_status_layer.c
@@ -16,9 +16,9 @@ static TextLayer *s_calendar_month_layer;
 static GBitmap *s_mute_bitmap;
 static GBitmap *s_bt_bitmap;
 static GBitmap *s_bt_disconnect_bitmap;
-static GColor *s_bt_palette;
-static GColor *s_bt_disconnect_palette;
-static GColor *s_mute_palette;
+static GColor s_bt_palette[2];
+static GColor s_bt_disconnect_palette[2];
+static GColor s_mute_palette[2];
 
 static void draw_bitmap(GContext *ctx, GBitmap *bitmap, GRect frame) {
     graphics_context_set_compositing_mode(ctx, GCompOpSet);
@@ -43,30 +43,39 @@ static void calendar_status_update_proc(Layer *layer, GContext *ctx) {
 }
 
 void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
+    MemoryHeapProbe probe = MEMORY_HEAP_PROBE_START("calendar_status_layer_create");
+
     s_calendar_status_layer = layer_create(frame);
+    MEMORY_HEAP_PROBE_SAMPLE("after_layer_create", &probe);
+
     GRect bounds = layer_get_bounds(s_calendar_status_layer);
     int w = bounds.size.w;
 
     // Set up icons
     s_mute_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_MUTE);
+    MEMORY_HEAP_PROBE_SAMPLE("after_mute_bitmap", &probe);
+
     s_bt_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_BT_CONNECT);
+    MEMORY_HEAP_PROBE_SAMPLE("after_bt_bitmap", &probe);
+
     s_bt_disconnect_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_BT_DISCONNECT);
+    MEMORY_HEAP_PROBE_SAMPLE("after_bt_disconnect_bitmap", &probe);
     
     // Set up color palette
-    s_bt_palette = malloc(2*sizeof(GColor));
     s_bt_palette[0] = PBL_IF_COLOR_ELSE(GColorPictonBlue, GColorWhite);
     s_bt_palette[1] = GColorClear;
     gbitmap_set_palette(s_bt_bitmap, s_bt_palette, false);
+    MEMORY_HEAP_PROBE_SAMPLE("after_bt_palette", &probe);
 
-    s_bt_disconnect_palette = malloc(2*sizeof(GColor));
     s_bt_disconnect_palette[0] = PBL_IF_COLOR_ELSE(GColorRed, GColorWhite);
     s_bt_disconnect_palette[1] = GColorClear;
     gbitmap_set_palette(s_bt_disconnect_bitmap, s_bt_disconnect_palette, false);
+    MEMORY_HEAP_PROBE_SAMPLE("after_bt_disconnect_palette", &probe);
 
-    s_mute_palette = malloc(2*sizeof(GColor));
     s_mute_palette[0] = GColorWhite;
     s_mute_palette[1] = GColorClear;
     gbitmap_set_palette(s_mute_bitmap, s_mute_palette, false);
+    MEMORY_HEAP_PROBE_SAMPLE("after_mute_palette", &probe);
 
     // Set up month text layer
     s_calendar_month_layer = text_layer_create(GRect(0, -MONTH_FONT_OFFSET, w, 25));
@@ -74,18 +83,29 @@ void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
     text_layer_set_text_alignment(s_calendar_month_layer, GTextAlignmentCenter);
     text_layer_set_text_color(s_calendar_month_layer, GColorWhite);
     text_layer_set_font(s_calendar_month_layer, fonts_get_system_font(FONT_KEY_GOTHIC_18));
+    MEMORY_HEAP_PROBE_SAMPLE("after_month_text_layer", &probe);
 
     // Set up bluetooth handler
     connection_service_subscribe((ConnectionHandlers) {
         .pebble_app_connection_handler = bluetooth_callback
     });
+    MEMORY_HEAP_PROBE_SAMPLE("after_connection_subscribe", &probe);
 
     calendar_status_layer_refresh();
     layer_add_child(s_calendar_status_layer, text_layer_get_layer(s_calendar_month_layer));
+    MEMORY_HEAP_PROBE_SAMPLE("after_month_child_added", &probe);
+
     layer_set_update_proc(s_calendar_status_layer, calendar_status_update_proc);
+    MEMORY_HEAP_PROBE_SAMPLE("after_update_proc_set", &probe);
+
     battery_layer_create(s_calendar_status_layer, GRect(w - BATTERY_W - PADDING, 1, BATTERY_W, BATTERY_H));
+    MEMORY_HEAP_PROBE_SAMPLE("after_battery_layer_create", &probe);
+
     layer_add_child(parent_layer, s_calendar_status_layer);
+    MEMORY_HEAP_PROBE_SAMPLE("after_parent_child_added", &probe);
+
     MEMORY_LOG_HEAP("after_calendar_status_layer_create");
+    MEMORY_HEAP_PROBE_LOG_MIN(&probe);
 }
 
 void bluetooth_icons_refresh(bool connected) {
@@ -123,9 +143,6 @@ void calendar_status_layer_refresh() {
 void calendar_status_layer_destroy() {
     MEMORY_LOG_HEAP("calendar_status_layer_destroy:before");
     battery_layer_destroy();
-    free(s_bt_palette);
-    free(s_bt_disconnect_palette);
-    free(s_mute_palette);
     gbitmap_destroy(s_mute_bitmap);
     gbitmap_destroy(s_bt_bitmap);
     gbitmap_destroy(s_bt_disconnect_bitmap);

--- a/src/c/layers/forecast_layer.c
+++ b/src/c/layers/forecast_layer.c
@@ -58,9 +58,10 @@ typedef struct
 } ForecastLayout;
 
 static Layer *s_forecast_layer;
-static TextLayer *s_hi_layer;
-static TextLayer *s_lo_layer;
 static int s_axis_left_w = LEFT_AXIS_GRAPH_INSET_DEFAULT;
+static int s_label_strip_w = LEFT_AXIS_LABEL_STRIP_MIN_W;
+static char s_buffer_lo[12];
+static char s_buffer_hi[12];
 
 static RenderSpec make_render_spec()
 {
@@ -594,6 +595,15 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
     graphics_context_set_fill_color(ctx, GColorBlack);
     graphics_fill_rect(ctx, GRect(0, 0, s_axis_left_w, h - BOTTOM_AXIS_H), 0, GCornerNone); // Paint over plot bleeding
     graphics_draw_line(ctx, GPoint(graph_bounds.origin.x, 0), GPoint(graph_bounds.origin.x, axis_y));
+    graphics_context_set_text_color(ctx, GColorWhite);
+    graphics_draw_text(ctx, s_buffer_hi,
+                       fonts_get_system_font(FONT_KEY_GOTHIC_18),
+                       GRect(0, -3, s_label_strip_w, TEMP_LABEL_H),
+                       GTextOverflowModeFill, GTextAlignmentRight, NULL);
+    graphics_draw_text(ctx, s_buffer_lo,
+                       fonts_get_system_font(FONT_KEY_GOTHIC_18),
+                       GRect(0, 22, s_label_strip_w, TEMP_LABEL_H),
+                       GTextOverflowModeFill, GTextAlignmentRight, NULL);
     MEMORY_HEAP_PROBE_LOG_MIN(&redraw_probe);
     MEMORY_LOG_HEAP("forecast_update:exit");
 }
@@ -607,10 +617,8 @@ static int temp_label_string_width(const char *text)
     return sz.w;
 }
 
-static void text_layers_refresh()
+static void text_labels_refresh()
 {
-    static char s_buffer_lo[12], s_buffer_hi[12];
-
     snprintf(s_buffer_hi, sizeof(s_buffer_hi), "%d", config_localize_temp(persist_get_temp_hi()));
     snprintf(s_buffer_lo, sizeof(s_buffer_lo), "%d", config_localize_temp(persist_get_temp_lo()));
 
@@ -627,6 +635,7 @@ static void text_layers_refresh()
     {
         label_strip_w = LEFT_AXIS_LABEL_STRIP_MIN_W;
     }
+    s_label_strip_w = label_strip_w;
     const int graph_inset_w = label_strip_w + LEFT_AXIS_LABEL_TO_GRAPH_GAP;
 
     if (graph_inset_w != s_axis_left_w)
@@ -634,37 +643,16 @@ static void text_layers_refresh()
         s_axis_left_w = graph_inset_w;
     }
 
-    text_layer_set_size(s_hi_layer, GSize(label_strip_w, TEMP_LABEL_H));
-    text_layer_set_size(s_lo_layer, GSize(label_strip_w, TEMP_LABEL_H));
-
-    text_layer_set_text(s_hi_layer, s_buffer_hi);
-    text_layer_set_text(s_lo_layer, s_buffer_lo);
 }
 
 void forecast_layer_create(Layer *parent_layer, GRect frame)
 {
     s_forecast_layer = layer_create(frame);
 
-    // Temperature HIGH
-    s_hi_layer = text_layer_create(GRect(0, -3, LEFT_AXIS_LABEL_STRIP_MIN_W, TEMP_LABEL_H));
-    text_layer_set_background_color(s_hi_layer, GColorClear);
-    text_layer_set_text_alignment(s_hi_layer, GTextAlignmentRight);
-    text_layer_set_text_color(s_hi_layer, GColorWhite);
-    text_layer_set_font(s_hi_layer, fonts_get_system_font(FONT_KEY_GOTHIC_18));
-    layer_add_child(s_forecast_layer, text_layer_get_layer(s_hi_layer));
-
-    // Temperature LOW
-    s_lo_layer = text_layer_create(GRect(0, 22, LEFT_AXIS_LABEL_STRIP_MIN_W, TEMP_LABEL_H));
-    text_layer_set_background_color(s_lo_layer, GColorClear);
-    text_layer_set_text_alignment(s_lo_layer, GTextAlignmentRight);
-    text_layer_set_text_color(s_lo_layer, GColorWhite);
-    text_layer_set_font(s_lo_layer, fonts_get_system_font(FONT_KEY_GOTHIC_18));
-    layer_add_child(s_forecast_layer, text_layer_get_layer(s_lo_layer));
-
     // Fill the contents with values
 
     layer_set_update_proc(s_forecast_layer, forecast_update_proc);
-    text_layers_refresh();
+    text_labels_refresh();
 
     // Add it as a child layer to the Window's root layer
     layer_add_child(parent_layer, s_forecast_layer);
@@ -673,7 +661,7 @@ void forecast_layer_create(Layer *parent_layer, GRect frame)
 
 void forecast_layer_refresh()
 {
-    text_layers_refresh();
+    text_labels_refresh();
     layer_mark_dirty(s_forecast_layer);
 #ifdef FCW2_ENABLE_MEMORY_LOGGING
     APP_LOG(APP_LOG_LEVEL_DEBUG, "MEM|forecast_refresh|entries=%d|free=%lu|used=%lu",
@@ -686,8 +674,6 @@ void forecast_layer_refresh()
 void forecast_layer_destroy()
 {
     MEMORY_LOG_HEAP("forecast_layer_destroy:before");
-    text_layer_destroy(s_hi_layer);
-    text_layer_destroy(s_lo_layer);
     layer_destroy(s_forecast_layer);
     MEMORY_LOG_HEAP("forecast_layer_destroy:after");
 }

--- a/wscript
+++ b/wscript
@@ -30,7 +30,7 @@ def build(ctx):
     with open('package.json') as package_file:
         package = json.load(package_file)
 
-    enable_memory_logging = package.get('buildProfile') == 'dev'
+    enable_memory_logging = os.environ.get('ENABLE_MEMORY_LOGGING', '').strip().lower() in ('1', 'true', 'yes', 'on')
 
     build_worker = os.path.exists('worker_src')
     binaries = []


### PR DESCRIPTION
- Replaces `BitmapLayer` objects with direct `graphics_draw_bitmap_in_rect` calls
- Replaces `TextLayer` objects with direct `graphics_draw_text` calls
- Decouples memory debug logging from dev profile, instead use `ENABLE_MEMORY_LOGGING=1` in `.env`

Frees at least 1KB heap on startup.

Refs:
- https://developer.rebble.io/docs/c/User_Interface/Layers/BitmapLayer/
- https://developer.rebble.io/docs/c/Graphics/Drawing_Primitives/#graphics_draw_bitmap_in_rect
- https://developer.rebble.io/docs/c/Graphics/Graphics_Context/