### PR TITLE
fix: skip weather fetch during geocode backoff

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+# Copilot Review Standards
+
+- Focus on correctness, regressions, security, performance, and missing tests.
+- Skip pure style/naming/comment nits unless they affect behavior or maintainability.
+- Check previous PR comments to make sure you're not being overly pedantic.

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -486,6 +486,11 @@ function fetch(provider, force) {
         return;
     }
 
+    if (provider.isGeocodeBackoffActive && provider.isGeocodeBackoffActive()) {
+        console.log('Skipping weather fetch: geocoding is in backoff cooldown.');
+        return;
+    }
+
     console.log('Fetching from ' + provider.name);
     var fetchStart = Date.now();
     var attempt = incrementFetchAttemptCounter();

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -486,7 +486,7 @@ function fetch(provider, force) {
         return;
     }
 
-    if (provider.isGeocodeBackoffActive && provider.isGeocodeBackoffActive()) {
+    if (typeof provider.isGeocodeBackoffActive === 'function' && provider.isGeocodeBackoffActive()) {
         console.log('Skipping weather fetch: geocoding is in backoff cooldown.');
         return;
     }

--- a/src/pkjs/weather/provider.js
+++ b/src/pkjs/weather/provider.js
@@ -485,11 +485,14 @@ WeatherProvider.prototype.withGpsCoordinates = function(callback, onFailure) {
 };
 
 WeatherProvider.prototype.withCoordinates = function(callback, onFailure) {
+    var locationOverride;
+
     this.usedGpsCache = false;
     this.gpsErrorCode = null;
     this.locationMode = null;
 
-    if (this.location === null) {
+    locationOverride = parseLocationOverride(this.location);
+    if (locationOverride.type === 'gps') {
         this.locationMode = 'gps';
         console.log('Using GPS');
         this.withGpsCoordinates(callback, onFailure);

--- a/src/pkjs/weather/provider.js
+++ b/src/pkjs/weather/provider.js
@@ -173,6 +173,15 @@ WeatherProvider.prototype.gpsOverride = function(location) {
     this.location = location;
 };
 
+/**
+ * Determine whether the provider is currently rate-limited for geocoding.
+ *
+ * @returns {boolean} True when forward geocoding should be skipped.
+ */
+WeatherProvider.prototype.isGeocodeBackoffActive = function() {
+    return isGeocodeBackoffActive();
+};
+
 WeatherProvider.prototype.withSunEvents = function(lat, lon, callback, onFailure) {
     /* The callback runs with an array of the next two sun events (i.e. 24 hours worth),
      * where each sun event contains a 'type' ('sunrise' or 'sunset') and a 'date' (of type Date)

--- a/src/pkjs/weather/provider.js
+++ b/src/pkjs/weather/provider.js
@@ -82,6 +82,16 @@ function readStoredJson(key) {
 }
 
 /**
+ * Normalize a location query for cache lookups.
+ *
+ * @param {string} location Query string.
+ * @returns {string} Normalized query string.
+ */
+function normalizeLocationQuery(location) {
+    return location.trim();
+}
+
+/**
  * Read the cached geocode result for the active location.
  *
  * @param {string} location Query string.
@@ -89,8 +99,9 @@ function readStoredJson(key) {
  */
 function readGeocodeCache(location) {
     var cachedGeocode = readStoredJson(GEOCODE_CACHE_KEY);
+    var normalizedLocation = normalizeLocationQuery(location);
 
-    if (cachedGeocode && cachedGeocode.query === location) {
+    if (cachedGeocode && normalizeLocationQuery(cachedGeocode.query) === normalizedLocation) {
         return cachedGeocode;
     }
 
@@ -107,7 +118,7 @@ function readGeocodeCache(location) {
  */
 function writeGeocodeCache(location, lat, lon) {
     localStorage.setItem(GEOCODE_CACHE_KEY, JSON.stringify({
-        query: location,
+        query: normalizeLocationQuery(location),
         lat: lat,
         lon: lon,
         time: Date.now()
@@ -276,20 +287,6 @@ WeatherProvider.prototype.withCityName = function(lat, lon, callback, onFailure)
 var r_lat_long = /^([-+]?\d*\.?\d+)\s*,\s*([-+]?\d*\.?\d+)$/;
 
 /**
- * Build the GPS override state.
- *
- * @returns {{ type: 'gps', query: null, latitude: null, longitude: null }} GPS override state.
- */
-function createGpsLocationOverrideState() {
-    return {
-        type: 'gps',
-        query: null,
-        latitude: null,
-        longitude: null
-    };
-}
-
-/**
  * Parse a location override into GPS, manual coordinates, or an address.
  *
  * @param {*} location Location override value.
@@ -299,13 +296,14 @@ function parseLocationOverride(location) {
     var trimmedLocation;
     var match;
 
-    if (typeof location !== 'string') {
-        return createGpsLocationOverrideState();
-    }
-
-    trimmedLocation = location.trim();
-    if (trimmedLocation.length === 0) {
-        return createGpsLocationOverrideState();
+    trimmedLocation = typeof location === 'string' ? normalizeLocationQuery(location) : null;
+    if (trimmedLocation === null || trimmedLocation.length === 0) {
+        return {
+            type: 'gps',
+            query: null,
+            latitude: null,
+            longitude: null
+        };
     }
 
     match = trimmedLocation.match(r_lat_long);

--- a/src/pkjs/weather/provider.js
+++ b/src/pkjs/weather/provider.js
@@ -100,9 +100,17 @@ function normalizeLocationQuery(location) {
 function readGeocodeCache(location) {
     var cachedGeocode = readStoredJson(GEOCODE_CACHE_KEY);
     var normalizedLocation = normalizeLocationQuery(location);
+    var cachedQuery;
 
-    if (cachedGeocode && normalizeLocationQuery(cachedGeocode.query) === normalizedLocation) {
-        return cachedGeocode;
+    if (cachedGeocode && typeof cachedGeocode.query === 'string') {
+        cachedQuery = normalizeLocationQuery(cachedGeocode.query);
+        if (cachedQuery === normalizedLocation) {
+            return cachedGeocode;
+        }
+    }
+
+    if (cachedGeocode && typeof cachedGeocode.query !== 'string') {
+        localStorage.removeItem(GEOCODE_CACHE_KEY);
     }
 
     return null;
@@ -123,26 +131,6 @@ function writeGeocodeCache(location, lat, lon) {
         lon: lon,
         time: Date.now()
     }));
-}
-
-/**
- * Determine whether geocoding is still in backoff.
- *
- * @returns {boolean} True when geocoding should be skipped.
- */
-function isGeocodeBackoffActive() {
-    var backoffData = readStoredJson(RATE_LIMIT_BACKOFF_KEY);
-
-    if (!backoffData) {
-        return false;
-    }
-
-    if (Date.now() < (backoffData.until || 0)) {
-        return true;
-    }
-
-    localStorage.removeItem(RATE_LIMIT_BACKOFF_KEY);
-    return false;
 }
 
 /**
@@ -191,6 +179,7 @@ WeatherProvider.prototype.gpsOverride = function(location) {
  */
 WeatherProvider.prototype.isGeocodeBackoffActive = function() {
     var locationOverride = parseLocationOverride(this.location);
+    var backoffData;
 
     if (locationOverride.type !== 'manual_address') {
         return false;
@@ -200,7 +189,17 @@ WeatherProvider.prototype.isGeocodeBackoffActive = function() {
         return false;
     }
 
-    return isGeocodeBackoffActive();
+    backoffData = readStoredJson(RATE_LIMIT_BACKOFF_KEY);
+    if (!backoffData) {
+        return false;
+    }
+
+    if (Date.now() < (backoffData.until || 0)) {
+        return true;
+    }
+
+    localStorage.removeItem(RATE_LIMIT_BACKOFF_KEY);
+    return false;
 };
 
 WeatherProvider.prototype.withSunEvents = function(lat, lon, callback, onFailure) {
@@ -363,7 +362,7 @@ WeatherProvider.prototype.withGeocodeCoordinates = function(callback, onFailure)
     }
 
     // Check rate limit backoff: skip geocoding if we're still in cooldown from a 429
-    if (isGeocodeBackoffActive()) {
+    if (this.isGeocodeBackoffActive()) {
         console.log('[!] Geocoding in backoff cooldown, skipping');
         onFailure(failure('forward_geocode', 'backoff'));
         return;

--- a/src/pkjs/weather/provider.js
+++ b/src/pkjs/weather/provider.js
@@ -287,7 +287,7 @@ function createGpsLocationOverrideState() {
  * Parse a location override into GPS, manual coordinates, or an address.
  *
  * @param {*} location Location override value.
- * @returns {{ type: 'gps'|'manual_coordinates'|'manual_address', query: ?string, latitude: ?string, longitude: ?string }} Parsed override state.
+ * @returns {{ type: 'gps'|'manual_coordinates'|'manual_address', query: string|null, latitude: string|null, longitude: string|null }} Parsed override state.
  */
 function parseLocationOverride(location) {
     var trimmedLocation;
@@ -349,19 +349,19 @@ WeatherProvider.prototype.withGeocodeCoordinates = function(callback, onFailure)
         + '&q=' + encodeURIComponent(locationOverride.query)
         + '&format=json';
 
-    // Check rate limit backoff: skip geocoding if we're still in cooldown from a 429
-    if (isGeocodeBackoffActive()) {
-        console.log('[!] Geocoding in backoff cooldown, skipping');
-        onFailure(failure('forward_geocode', 'backoff'));
-        return;
-    }
-
-    // Check geocode cache: if the same address string was resolved before, reuse it
+    // Keep cached coordinates usable even while LocationIQ is in backoff.
     cachedGeocode = readGeocodeCache(locationOverride.query);
     if (cachedGeocode !== null) {
         console.log('Using cached geocode for: ' + locationOverride.query);
         this.locationMode = 'manual_address';
         callback(cachedGeocode.lat, cachedGeocode.lon);
+        return;
+    }
+
+    // Check rate limit backoff: skip geocoding if we're still in cooldown from a 429
+    if (isGeocodeBackoffActive()) {
+        console.log('[!] Geocoding in backoff cooldown, skipping');
+        onFailure(failure('forward_geocode', 'backoff'));
         return;
     }
 

--- a/src/pkjs/weather/provider.js
+++ b/src/pkjs/weather/provider.js
@@ -179,7 +179,13 @@ WeatherProvider.prototype.gpsOverride = function(location) {
  * @returns {boolean} True when forward geocoding should be skipped.
  */
 WeatherProvider.prototype.isGeocodeBackoffActive = function() {
-    if (parseLocationOverride(this.location).type !== 'manual_address') {
+    var locationOverride = parseLocationOverride(this.location);
+
+    if (locationOverride.type !== 'manual_address') {
+        return false;
+    }
+
+    if (readGeocodeCache(locationOverride.query) !== null) {
         return false;
     }
 

--- a/src/pkjs/weather/provider.js
+++ b/src/pkjs/weather/provider.js
@@ -179,13 +179,7 @@ WeatherProvider.prototype.gpsOverride = function(location) {
  * @returns {boolean} True when forward geocoding should be skipped.
  */
 WeatherProvider.prototype.isGeocodeBackoffActive = function() {
-    // GPS mode and empty overrides never forward a location string to LocationIQ.
-    if (typeof this.location !== 'string' || this.location.trim().length === 0) {
-        return false;
-    }
-
-    // Raw lat/long overrides bypass forward geocoding entirely.
-    if (r_lat_long.test(this.location.trim())) {
+    if (parseLocationOverride(this.location).type !== 'manual_address') {
         return false;
     }
 
@@ -275,27 +269,85 @@ WeatherProvider.prototype.withCityName = function(lat, lon, callback, onFailure)
 // https://github.com/mattrossman/forecaswatch2/issues/59#issue-1317582743
 var r_lat_long = /^([-+]?\d*\.?\d+)\s*,\s*([-+]?\d*\.?\d+)$/;
 
+/**
+ * Build the GPS override state.
+ *
+ * @returns {{ type: 'gps', query: null, latitude: null, longitude: null }} GPS override state.
+ */
+function createGpsLocationOverrideState() {
+    return {
+        type: 'gps',
+        query: null,
+        latitude: null,
+        longitude: null
+    };
+}
+
+/**
+ * Parse a location override into GPS, manual coordinates, or an address.
+ *
+ * @param {*} location Location override value.
+ * @returns {{ type: 'gps'|'manual_coordinates'|'manual_address', query: ?string, latitude: ?string, longitude: ?string }} Parsed override state.
+ */
+function parseLocationOverride(location) {
+    var trimmedLocation;
+    var match;
+
+    if (typeof location !== 'string') {
+        return createGpsLocationOverrideState();
+    }
+
+    trimmedLocation = location.trim();
+    if (trimmedLocation.length === 0) {
+        return createGpsLocationOverrideState();
+    }
+
+    match = trimmedLocation.match(r_lat_long);
+    if (match !== null) {
+        return {
+            type: 'manual_coordinates',
+            query: trimmedLocation,
+            latitude: match[1],
+            longitude: match[2]
+        };
+    }
+
+    return {
+        type: 'manual_address',
+        query: trimmedLocation,
+        latitude: null,
+        longitude: null
+    };
+}
+
 WeatherProvider.prototype.withGeocodeCoordinates = function(callback, onFailure) {
     // callback(latitude, longitude)
     var locationiqKey = 'pk.5a61972cde94491774bcfaa0705d5a0d';
-    var url = 'https://us1.locationiq.com/v1/search.php?key=' + locationiqKey
-        + '&q=' + encodeURIComponent(this.location)
-        + '&format=json';
-    var m = this.location.match(r_lat_long);
+    var locationOverride = parseLocationOverride(this.location);
+    var url;
     var latitude;
     var longitude;
     var cachedGeocode;
     var backoffMs;
 
-    console.log('WeatherProvider.prototype.withGeocodeCoordinates regex, this.location: ' + JSON.stringify(this.location));
-    if (m !== null) {
-        latitude = m[1];
-        longitude = m[2];
+    console.log('WeatherProvider.prototype.withGeocodeCoordinates override: ' + JSON.stringify(this.location));
+    if (locationOverride.type === 'manual_coordinates') {
+        latitude = locationOverride.latitude;
+        longitude = locationOverride.longitude;
         this.locationMode = 'manual_coordinates';
         console.log('regex matched, override is lat/long');
         callback(latitude, longitude);
         return;
     }
+
+    if (locationOverride.type !== 'manual_address') {
+        onFailure(failure('forward_geocode', 'invalid_location'));
+        return;
+    }
+
+    url = 'https://us1.locationiq.com/v1/search.php?key=' + locationiqKey
+        + '&q=' + encodeURIComponent(locationOverride.query)
+        + '&format=json';
 
     // Check rate limit backoff: skip geocoding if we're still in cooldown from a 429
     if (isGeocodeBackoffActive()) {
@@ -305,16 +357,16 @@ WeatherProvider.prototype.withGeocodeCoordinates = function(callback, onFailure)
     }
 
     // Check geocode cache: if the same address string was resolved before, reuse it
-    cachedGeocode = readGeocodeCache(this.location);
+    cachedGeocode = readGeocodeCache(locationOverride.query);
     if (cachedGeocode !== null) {
-        console.log('Using cached geocode for: ' + this.location);
+        console.log('Using cached geocode for: ' + locationOverride.query);
         this.locationMode = 'manual_address';
         callback(cachedGeocode.lat, cachedGeocode.lon);
         return;
     }
 
     this.locationMode = 'manual_address';
-    console.log('regex failed, about to look up lat/long for override');
+    console.log('Looking up coordinates for address override');
     request(
         url,
         'GET',
@@ -336,9 +388,9 @@ WeatherProvider.prototype.withGeocodeCoordinates = function(callback, onFailure)
             }
 
             closest = locations[0];
-            console.log('Query ' + this.location + ' geocoded to ' + closest.lat + ', ' + closest.lon);
+            console.log('Query ' + locationOverride.query + ' geocoded to ' + closest.lat + ', ' + closest.lon);
             // Cache the successful geocode result
-            writeGeocodeCache(this.location, closest.lat, closest.lon);
+            writeGeocodeCache(locationOverride.query, closest.lat, closest.lon);
             callback(closest.lat, closest.lon);
         }).bind(this),
         (function(error) {

--- a/src/pkjs/weather/provider.js
+++ b/src/pkjs/weather/provider.js
@@ -179,6 +179,18 @@ WeatherProvider.prototype.gpsOverride = function(location) {
  * @returns {boolean} True when forward geocoding should be skipped.
  */
 WeatherProvider.prototype.isGeocodeBackoffActive = function() {
+    if (typeof this.location !== 'string') {
+        return false;
+    }
+
+    if (this.location.trim().length === 0) {
+        return false;
+    }
+
+    if (r_lat_long.test(this.location.trim())) {
+        return false;
+    }
+
     return isGeocodeBackoffActive();
 };
 

--- a/src/pkjs/weather/provider.js
+++ b/src/pkjs/weather/provider.js
@@ -179,14 +179,12 @@ WeatherProvider.prototype.gpsOverride = function(location) {
  * @returns {boolean} True when forward geocoding should be skipped.
  */
 WeatherProvider.prototype.isGeocodeBackoffActive = function() {
-    if (typeof this.location !== 'string') {
+    // GPS mode and empty overrides never forward a location string to LocationIQ.
+    if (typeof this.location !== 'string' || this.location.trim().length === 0) {
         return false;
     }
 
-    if (this.location.trim().length === 0) {
-        return false;
-    }
-
+    // Raw lat/long overrides bypass forward geocoding entirely.
     if (r_lat_long.test(this.location.trim())) {
         return false;
     }


### PR DESCRIPTION
- Short-circuit fetches while geocode cooldown is active so they never count as attempts
- Prevents minute-by-minute telemetry spam from backoff-only skips