### PR TITLE
feat: lazy-load status bitmaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,12 @@ If you need runtime logs, `mise install-emulator --logs` runs it in an emulator 
 - Heap probes: use `MEMORY_LOG_HEAP("tag")` for dev-only `MEM|...` logs around lifecycle and redraw checkpoints.
 - JS: `console.log("msg")`
 
+## Pebble Memory Tips
+
+- Lazy-load bitmaps and destroy them when they are not needed to keep startup and steady-state heap usage low.
+- Prefer drawing directly in an update proc over creating extra layer objects when a simple render path is enough.
+- If a UI element only exists to paint pixels, keep it as light as possible instead of modeling it as a full layer.
+
 ## JavaScript Conventions
 
 - For new JavaScript functions, add brief JSDoc (`@param`/`@returns`) annotations since this project does not use TypeScript.

--- a/src/c/layers/battery_layer.c
+++ b/src/c/layers/battery_layer.c
@@ -7,6 +7,7 @@
 #define BATTERY_STROKE 1
 #define FILL_PADDING 1
 #define ICON_SPACING 3
+#define BATTERY_POWER_ICON_W 7
 
 
 static Layer *s_battery_layer;
@@ -26,6 +27,22 @@ static GColor get_battery_color(int level) {
         return GColorRed;
 }
 
+static void ensure_battery_power_bitmap_loaded(void) {
+    if (!s_battery_power_bitmap) {
+        s_battery_power_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_BATTERY_CHARGING);
+        s_battery_palette[0] = GColorWhite;
+        s_battery_palette[1] = GColorClear;
+        gbitmap_set_palette(s_battery_power_bitmap, s_battery_palette, false);
+    }
+}
+
+static void maybe_unload_battery_power_bitmap(bool show_power_icon) {
+    if (!show_power_icon && s_battery_power_bitmap) {
+        gbitmap_destroy(s_battery_power_bitmap);
+        s_battery_power_bitmap = NULL;
+    }
+}
+
 static void draw_power_icon(GContext *ctx, int h, GBitmap *icon_bitmap) {
     GRect icon_bounds = gbitmap_get_bounds(icon_bitmap);
     int icon_x = 0;
@@ -43,13 +60,15 @@ static void battery_update_proc(Layer *layer, GContext *ctx) {
     GRect bounds = layer_get_bounds(layer);
     int w = bounds.size.w;
     int h = bounds.size.h;
-    int icon_w = gbitmap_get_bounds(s_battery_power_bitmap).size.w;
-    int battery_x = icon_w + ICON_SPACING;
-    int battery_total_w = w - battery_x;
-    int battery_w = battery_total_w - BATTERY_NUB_W;
     BatteryChargeState battery_state = battery_state_service_peek();
     int battery_level = battery_state.charge_percent;
     bool show_power_icon = battery_state.is_charging || battery_state.is_plugged;
+
+    maybe_unload_battery_power_bitmap(show_power_icon);
+
+    int battery_x = BATTERY_POWER_ICON_W + ICON_SPACING;
+    int battery_total_w = w - battery_x;
+    int battery_w = battery_total_w - BATTERY_NUB_W;
 
     // Fill the battery level
     GRect color_bounds = GRect(
@@ -62,6 +81,7 @@ static void battery_update_proc(Layer *layer, GContext *ctx) {
     graphics_fill_rect(ctx, color_area, 0, GCornerNone);
 
     if (show_power_icon) {
+        ensure_battery_power_bitmap_loaded();
         draw_power_icon(ctx, h, s_battery_power_bitmap);
     }
 
@@ -82,14 +102,6 @@ void battery_layer_create(Layer* parent_layer, GRect frame) {
     s_battery_layer = layer_create(frame);
     MEMORY_HEAP_PROBE_SAMPLE("after_layer_create", &probe);
 
-    s_battery_power_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_BATTERY_CHARGING);
-    MEMORY_HEAP_PROBE_SAMPLE("after_bitmap_create", &probe);
-
-    s_battery_palette[0] = GColorWhite;
-    s_battery_palette[1] = GColorClear;
-    gbitmap_set_palette(s_battery_power_bitmap, s_battery_palette, false);
-    MEMORY_HEAP_PROBE_SAMPLE("after_palette_set", &probe);
-
     layer_set_update_proc(s_battery_layer, battery_update_proc);
     battery_state_service_subscribe(battery_state_handler);
     MEMORY_HEAP_PROBE_SAMPLE("after_battery_subscribe", &probe);
@@ -106,7 +118,7 @@ void battery_layer_refresh() {
 void battery_layer_destroy() {
     MEMORY_LOG_HEAP("battery_layer_destroy:before");
     battery_state_service_unsubscribe();
-    gbitmap_destroy(s_battery_power_bitmap);
+    if (s_battery_power_bitmap) gbitmap_destroy(s_battery_power_bitmap);
     layer_destroy(s_battery_layer);
     MEMORY_LOG_HEAP("battery_layer_destroy:after");
 }

--- a/src/c/layers/battery_layer.c
+++ b/src/c/layers/battery_layer.c
@@ -118,7 +118,10 @@ void battery_layer_refresh() {
 void battery_layer_destroy() {
     MEMORY_LOG_HEAP("battery_layer_destroy:before");
     battery_state_service_unsubscribe();
-    if (s_battery_power_bitmap) gbitmap_destroy(s_battery_power_bitmap);
+    if (s_battery_power_bitmap) {
+        gbitmap_destroy(s_battery_power_bitmap);
+        s_battery_power_bitmap = NULL;
+    }
     layer_destroy(s_battery_layer);
     MEMORY_LOG_HEAP("battery_layer_destroy:after");
 }

--- a/src/c/layers/calendar_status_layer.c
+++ b/src/c/layers/calendar_status_layer.c
@@ -171,9 +171,18 @@ void calendar_status_layer_refresh() {
 void calendar_status_layer_destroy() {
     MEMORY_LOG_HEAP("calendar_status_layer_destroy:before");
     battery_layer_destroy();
-    if (s_mute_bitmap) gbitmap_destroy(s_mute_bitmap);
-    if (s_bt_bitmap) gbitmap_destroy(s_bt_bitmap);
-    if (s_bt_disconnect_bitmap) gbitmap_destroy(s_bt_disconnect_bitmap);
+    if (s_mute_bitmap) {
+        gbitmap_destroy(s_mute_bitmap);
+        s_mute_bitmap = NULL;
+    }
+    if (s_bt_bitmap) {
+        gbitmap_destroy(s_bt_bitmap);
+        s_bt_bitmap = NULL;
+    }
+    if (s_bt_disconnect_bitmap) {
+        gbitmap_destroy(s_bt_disconnect_bitmap);
+        s_bt_disconnect_bitmap = NULL;
+    }
     layer_destroy(s_calendar_status_layer);
     MEMORY_LOG_HEAP("calendar_status_layer_destroy:after");
 }

--- a/src/c/layers/calendar_status_layer.c
+++ b/src/c/layers/calendar_status_layer.c
@@ -26,18 +26,72 @@ static void draw_bitmap(GContext *ctx, GBitmap *bitmap, GRect frame) {
     graphics_context_set_compositing_mode(ctx, GCompOpAssign);
 }
 
+static void ensure_mute_bitmap_loaded(void) {
+    if (!s_mute_bitmap) {
+        s_mute_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_MUTE);
+        s_mute_palette[0] = GColorWhite;
+        s_mute_palette[1] = GColorClear;
+        gbitmap_set_palette(s_mute_bitmap, s_mute_palette, false);
+    }
+}
+
+static void ensure_bt_bitmap_loaded(void) {
+    if (!s_bt_bitmap) {
+        s_bt_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_BT_CONNECT);
+        s_bt_palette[0] = PBL_IF_COLOR_ELSE(GColorPictonBlue, GColorWhite);
+        s_bt_palette[1] = GColorClear;
+        gbitmap_set_palette(s_bt_bitmap, s_bt_palette, false);
+    }
+}
+
+static void ensure_bt_disconnect_bitmap_loaded(void) {
+    if (!s_bt_disconnect_bitmap) {
+        s_bt_disconnect_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_BT_DISCONNECT);
+        s_bt_disconnect_palette[0] = PBL_IF_COLOR_ELSE(GColorRed, GColorWhite);
+        s_bt_disconnect_palette[1] = GColorClear;
+        gbitmap_set_palette(s_bt_disconnect_bitmap, s_bt_disconnect_palette, false);
+    }
+}
+
+static void maybe_unload_calendar_status_bitmaps(bool show_qt, bool connected) {
+    bool show_bt = connected && g_config->show_bt;
+    bool show_bt_disconnect = !connected && g_config->show_bt_disconnect;
+
+    if (!show_qt && s_mute_bitmap) {
+        gbitmap_destroy(s_mute_bitmap);
+        s_mute_bitmap = NULL;
+    }
+
+    if (!show_bt && s_bt_bitmap) {
+        gbitmap_destroy(s_bt_bitmap);
+        s_bt_bitmap = NULL;
+    }
+
+    if (!show_bt_disconnect && s_bt_disconnect_bitmap) {
+        gbitmap_destroy(s_bt_disconnect_bitmap);
+        s_bt_disconnect_bitmap = NULL;
+    }
+}
+
 static void calendar_status_update_proc(Layer *layer, GContext *ctx) {
     bool show_qt = show_qt_icon();
     bool connected = connection_service_peek_pebble_app_connection();
     int icon_x = show_qt ? ICON_SLOT_2.origin.x : ICON_SLOT_1.origin.x;
+    bool show_bt = connected && g_config->show_bt;
+    bool show_bt_disconnect = !connected && g_config->show_bt_disconnect;
+
+    maybe_unload_calendar_status_bitmaps(show_qt, connected);
 
     if (show_qt) {
+        ensure_mute_bitmap_loaded();
         draw_bitmap(ctx, s_mute_bitmap, ICON_SLOT_1);
     }
 
-    if (connected && g_config->show_bt) {
+    if (show_bt) {
+        ensure_bt_bitmap_loaded();
         draw_bitmap(ctx, s_bt_bitmap, GRect(icon_x, 0, 10, 10));
-    } else if (!connected && g_config->show_bt_disconnect) {
+    } else if (show_bt_disconnect) {
+        ensure_bt_disconnect_bitmap_loaded();
         draw_bitmap(ctx, s_bt_disconnect_bitmap, GRect(icon_x, 0, 10, 10));
     }
 }
@@ -50,32 +104,6 @@ void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
 
     GRect bounds = layer_get_bounds(s_calendar_status_layer);
     int w = bounds.size.w;
-
-    // Set up icons
-    s_mute_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_MUTE);
-    MEMORY_HEAP_PROBE_SAMPLE("after_mute_bitmap", &probe);
-
-    s_bt_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_BT_CONNECT);
-    MEMORY_HEAP_PROBE_SAMPLE("after_bt_bitmap", &probe);
-
-    s_bt_disconnect_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_BT_DISCONNECT);
-    MEMORY_HEAP_PROBE_SAMPLE("after_bt_disconnect_bitmap", &probe);
-    
-    // Set up color palette
-    s_bt_palette[0] = PBL_IF_COLOR_ELSE(GColorPictonBlue, GColorWhite);
-    s_bt_palette[1] = GColorClear;
-    gbitmap_set_palette(s_bt_bitmap, s_bt_palette, false);
-    MEMORY_HEAP_PROBE_SAMPLE("after_bt_palette", &probe);
-
-    s_bt_disconnect_palette[0] = PBL_IF_COLOR_ELSE(GColorRed, GColorWhite);
-    s_bt_disconnect_palette[1] = GColorClear;
-    gbitmap_set_palette(s_bt_disconnect_bitmap, s_bt_disconnect_palette, false);
-    MEMORY_HEAP_PROBE_SAMPLE("after_bt_disconnect_palette", &probe);
-
-    s_mute_palette[0] = GColorWhite;
-    s_mute_palette[1] = GColorClear;
-    gbitmap_set_palette(s_mute_bitmap, s_mute_palette, false);
-    MEMORY_HEAP_PROBE_SAMPLE("after_mute_palette", &probe);
 
     // Set up month text layer
     s_calendar_month_layer = text_layer_create(GRect(0, -MONTH_FONT_OFFSET, w, 25));
@@ -143,9 +171,9 @@ void calendar_status_layer_refresh() {
 void calendar_status_layer_destroy() {
     MEMORY_LOG_HEAP("calendar_status_layer_destroy:before");
     battery_layer_destroy();
-    gbitmap_destroy(s_mute_bitmap);
-    gbitmap_destroy(s_bt_bitmap);
-    gbitmap_destroy(s_bt_disconnect_bitmap);
+    if (s_mute_bitmap) gbitmap_destroy(s_mute_bitmap);
+    if (s_bt_bitmap) gbitmap_destroy(s_bt_bitmap);
+    if (s_bt_disconnect_bitmap) gbitmap_destroy(s_bt_disconnect_bitmap);
     layer_destroy(s_calendar_status_layer);
     MEMORY_LOG_HEAP("calendar_status_layer_destroy:after");
 }


### PR DESCRIPTION
## Summary
- Lazy-load Pebble status bitmaps to reduce startup and steady-state heap usage.
- Add AGENTS notes for bitmap lazy-loading and direct-draw memory optimizations.

Closes #124 