### PR TITLE
fix: refetch weather when watch starts empty

### DIFF
--- a/package.template.json
+++ b/package.template.json
@@ -69,6 +69,7 @@
       "CURRENT_TEMP",
       "CITY",
       "SUN_EVENTS",
+      "WATCH_HAS_FORECAST_DATA",
       "CLAY_CELSIUS",
       "CLAY_TIME_LEAD_ZERO",
       "CLAY_AXIS_12H",

--- a/src/c/appendix/app_message.c
+++ b/src/c/appendix/app_message.c
@@ -124,6 +124,23 @@ static void inbox_dropped_callback(AppMessageResult reason, void *context) {
     APP_LOG(APP_LOG_LEVEL_ERROR, "Message dropped!");
 }
 
+void app_message_send_startup_state(bool has_forecast_data) {
+    DictionaryIterator *outbox;
+    AppMessageResult result = app_message_outbox_begin(&outbox);
+
+    if (result != APP_MSG_OK) {
+        APP_LOG(APP_LOG_LEVEL_ERROR, "Unable to begin startup outbox: %d", result);
+        return;
+    }
+
+    dict_write_uint8(outbox, MESSAGE_KEY_WATCH_HAS_FORECAST_DATA, has_forecast_data ? 1 : 0);
+    result = app_message_outbox_send();
+
+    if (result != APP_MSG_OK) {
+        APP_LOG(APP_LOG_LEVEL_ERROR, "Unable to send startup state: %d", result);
+    }
+}
+
 void app_message_init() {
     // Register callbacks
     app_message_register_inbox_received(inbox_received_callback);
@@ -131,7 +148,8 @@ void app_message_init() {
 
     // Open AppMessage
     const int inbox_size = 256;
-    const int outbox_size = 0;
+    const int outbox_size = dict_calc_buffer_size(1, sizeof(uint8_t));
+    APP_LOG(APP_LOG_LEVEL_INFO, "AppMessage buffer sizes: inbox=%d outbox=%d", inbox_size, outbox_size);
     app_message_open(inbox_size, outbox_size);
     MEMORY_LOG_HEAP("after_app_message_open");
 }

--- a/src/c/appendix/app_message.h
+++ b/src/c/appendix/app_message.h
@@ -3,3 +3,5 @@
 #include <pebble.h>
 
 void app_message_init();
+
+void app_message_send_startup_state(bool has_forecast_data);

--- a/src/c/layers/loading_layer.c
+++ b/src/c/layers/loading_layer.c
@@ -5,6 +5,13 @@
 static Layer *s_loading_layer;
 static TextLayer *s_loading_text_layer;
 
+bool loading_layer_has_valid_data() {
+    const time_t forecast_start = persist_get_forecast_start();
+    const time_t now = time(NULL);
+
+    return now - forecast_start <= 60 * 60 * 12;
+}
+
 static void loading_update_proc(Layer *layer, GContext *ctx) {
     GRect bounds = layer_get_bounds(layer);
     int w = bounds.size.w;
@@ -34,12 +41,10 @@ void loading_layer_create(Layer* parent_layer, GRect frame) {
 }
 
 void loading_layer_refresh() {
-    const time_t forecast_start = persist_get_forecast_start();
-    const time_t now = time(NULL);
-    if (now - forecast_start > 60 * 60 * 12) // 60 sec/min * 60 min/h * 12h
-        layer_set_hidden(s_loading_layer, false); // show the no data notice
+    if (loading_layer_has_valid_data())
+        layer_set_hidden(s_loading_layer, true);
     else
-        layer_set_hidden(s_loading_layer, true); // hide the no data notice
+        layer_set_hidden(s_loading_layer, false); // show the no data notice
 }
 
 void loading_layer_destroy() {

--- a/src/c/layers/loading_layer.h
+++ b/src/c/layers/loading_layer.h
@@ -4,6 +4,8 @@
 
 void loading_layer_create(Layer* parent_layer, GRect frame);
 
+bool loading_layer_has_valid_data();
+
 void loading_layer_refresh();
 
 void loading_layer_destroy();

--- a/src/c/windows/main_window.c
+++ b/src/c/windows/main_window.c
@@ -5,6 +5,7 @@
 #include "c/layers/calendar_layer.h"
 #include "c/layers/calendar_status_layer.h"
 #include "c/layers/loading_layer.h"
+#include "c/appendix/app_message.h"
 #include "c/appendix/persist.h"
 #include "c/appendix/memory_log.h"
 
@@ -38,6 +39,7 @@ static void main_window_load(Window *window) {
     loading_layer_create(window_layer,
             GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, w, FORECAST_HEIGHT + WEATHER_STATUS_HEIGHT));
     loading_layer_refresh();
+    app_message_send_startup_state(loading_layer_has_valid_data());
     MEMORY_LOG_HEAP("after_window_load");
 }
 

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -48,7 +48,13 @@ app.fetchInProgress = false;
 app.pendingStartupFetch = false;
 
 Pebble.addEventListener('appmessage', function(e) {
-    var hasForecastData = Boolean(e && e.payload && e.payload.WATCH_HAS_FORECAST_DATA);
+    var payload = e && e.payload;
+
+    if (!payload || !Object.prototype.hasOwnProperty.call(payload, 'WATCH_HAS_FORECAST_DATA')) {
+        return;
+    }
+
+    var hasForecastData = Boolean(payload.WATCH_HAS_FORECAST_DATA);
 
     if (hasForecastData) {
         console.log('Watch reported valid forecast data at startup.');

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -25,6 +25,17 @@ function loadReleaseNotificationsManifest() {
 
 var releaseNotificationsManifest = loadReleaseNotificationsManifest();
 var clay = new Clay(clayConfig, customClay, { autoHandleEvents: false });
+/**
+ * @type {{
+ *     fetchInProgress: boolean,
+ *     pendingStartupFetch: boolean,
+ *     settings?: Object,
+ *     telemetry?: Object,
+ *     provider?: Object,
+ *     watchInfo?: Object,
+ *     devConfig?: Object
+ * }}
+ */
 var app = {};  // Namespace for global app variables
 var KEY_MAX_NOTIFIED_VERSION = 'max_notified_version';
 var KEY_FETCH_ATTEMPT = storageKeys.FETCH_ATTEMPT_KEY;
@@ -32,6 +43,27 @@ var KEY_LAST_FETCH_SUCCESS = storageKeys.LAST_FETCH_SUCCESS_KEY;
 var KEY_LAST_FETCH_ATTEMPT = storageKeys.LAST_FETCH_ATTEMPT_KEY;
 var KEY_GEOCODE_CACHE = storageKeys.GEOCODE_CACHE_KEY;
 var KEY_GEOCODE_BACKOFF = storageKeys.GEOCODE_BACKOFF_KEY;
+
+app.fetchInProgress = false;
+app.pendingStartupFetch = false;
+
+Pebble.addEventListener('appmessage', function(e) {
+    var hasForecastData = Boolean(e && e.payload && e.payload.WATCH_HAS_FORECAST_DATA);
+
+    if (hasForecastData) {
+        console.log('Watch reported valid forecast data at startup.');
+        app.pendingStartupFetch = false;
+        return;
+    }
+
+    console.log('Watch reported no forecast data at startup.');
+    app.pendingStartupFetch = true;
+
+    if (app.provider) {
+        app.pendingStartupFetch = false;
+        fetch(app.provider, true);
+    }
+});
 
 Pebble.addEventListener('showConfiguration', function(e) {
     // Set the userData here rather than in the Clay() constructor so it's actually up to date
@@ -83,6 +115,10 @@ Pebble.addEventListener('ready',
         }
         app.telemetry = createTelemetryClient(getRuntimeTelemetryConfig());
         refreshProvider();
+        if (app.pendingStartupFetch) {
+            app.pendingStartupFetch = false;
+            fetch(app.provider, true);
+        }
         startTick();
     }
 );
@@ -486,12 +522,18 @@ function fetch(provider, force) {
         return;
     }
 
+    if (app.fetchInProgress) {
+        console.log('Skipping weather fetch: another fetch is already in progress.');
+        return;
+    }
+
     if (typeof provider.isGeocodeBackoffActive === 'function' && provider.isGeocodeBackoffActive()) {
         console.log('Skipping weather fetch: geocoding is in backoff cooldown.');
         return;
     }
 
     console.log('Fetching from ' + provider.name);
+    app.fetchInProgress = true;
     var fetchStart = Date.now();
     var attempt = incrementFetchAttemptCounter();
     var fetchStatus = {
@@ -500,51 +542,59 @@ function fetch(provider, force) {
         name: provider.name
     }
     localStorage.setItem(KEY_LAST_FETCH_ATTEMPT, JSON.stringify(fetchStatus));
-    provider.fetch(
-        function() {
-            // Sucess, update recent fetch time
-            localStorage.setItem(KEY_LAST_FETCH_SUCCESS, JSON.stringify(fetchStatus));
-            resetFetchAttemptCounter();
-            console.log('Successfully fetched weather!');
-            maybeTrackWeatherFetch({
-                provider: provider.id,
-                success: true,
-                attempt: attempt,
-                usedGpsCache: provider.usedGpsCache,
-                gpsErrorCode: provider.gpsErrorCode,
-                locationMode: provider.locationMode,
-                countryCode: provider.countryCode,
-                settings: app.settings,
-                watchInfo: app.watchInfo,
-                durationMs: Date.now() - fetchStart
-            });
-        },
-        function(failure) {
-            // Failure
-            console.log('[!] Provider failed to update weather: ' + JSON.stringify(failure));
-            var attemptStatus = {
-                time: fetchStatus.time,
-                id: fetchStatus.id,
-                name: fetchStatus.name,
-                error: failure
-            };
-            localStorage.setItem(KEY_LAST_FETCH_ATTEMPT, JSON.stringify(attemptStatus));
-            maybeTrackWeatherFetch({
-                provider: provider.id,
-                success: false,
-                attempt: attempt,
-                usedGpsCache: provider.usedGpsCache,
-                gpsErrorCode: provider.gpsErrorCode,
-                locationMode: provider.locationMode,
-                countryCode: provider.countryCode,
-                error: failure,
-                settings: app.settings,
-                watchInfo: app.watchInfo,
-                durationMs: Date.now() - fetchStart
-            });
-        },
-        force
-    )
+    try {
+        provider.fetch(
+            function() {
+                // Sucess, update recent fetch time
+                app.fetchInProgress = false;
+                localStorage.setItem(KEY_LAST_FETCH_SUCCESS, JSON.stringify(fetchStatus));
+                resetFetchAttemptCounter();
+                console.log('Successfully fetched weather!');
+                maybeTrackWeatherFetch({
+                    provider: provider.id,
+                    success: true,
+                    attempt: attempt,
+                    usedGpsCache: provider.usedGpsCache,
+                    gpsErrorCode: provider.gpsErrorCode,
+                    locationMode: provider.locationMode,
+                    countryCode: provider.countryCode,
+                    settings: app.settings,
+                    watchInfo: app.watchInfo,
+                    durationMs: Date.now() - fetchStart
+                });
+            },
+            function(failure) {
+                // Failure
+                app.fetchInProgress = false;
+                console.log('[!] Provider failed to update weather: ' + JSON.stringify(failure));
+                var attemptStatus = {
+                    time: fetchStatus.time,
+                    id: fetchStatus.id,
+                    name: fetchStatus.name,
+                    error: failure
+                };
+                localStorage.setItem(KEY_LAST_FETCH_ATTEMPT, JSON.stringify(attemptStatus));
+                maybeTrackWeatherFetch({
+                    provider: provider.id,
+                    success: false,
+                    attempt: attempt,
+                    usedGpsCache: provider.usedGpsCache,
+                    gpsErrorCode: provider.gpsErrorCode,
+                    locationMode: provider.locationMode,
+                    countryCode: provider.countryCode,
+                    error: failure,
+                    settings: app.settings,
+                    watchInfo: app.watchInfo,
+                    durationMs: Date.now() - fetchStart
+                });
+            },
+            force
+        )
+    }
+    catch (e) {
+        app.fetchInProgress = false;
+        console.log('Weather fetch threw synchronously: ' + e.message);
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Force a weather fetch when the watch reports it has no forecast data at startup
- Keep the existing freshness gate when the watch already has valid data
- Add a startup log for the computed AppMessage outbox size