### PR TITLE
chore: add memory report to build preview comment

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -41,7 +41,11 @@ jobs:
       - name: Build dev .pbw
         env:
           TELEMETRY_ENDPOINT: ${{ secrets.TELEMETRY_ENDPOINT_PREVIEW }}
-        run: mise build dev
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          mise build dev 2>&1 | tee build/build-preview.log
 
       - name: Verify artifact exists
         run: test -f build/forecaswatch2-dev.pbw
@@ -59,8 +63,12 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+          MEMORY_LOG_PATH: ${{ github.workspace }}/build/build-preview.log
         with:
           script: |
+            const fs = require('node:fs');
+            const { parsePebbleMemoryReport, renderPebbleMemoryReport } = require(`${process.env.GITHUB_WORKSPACE}/scripts/parse-pebble-memory-report`);
+
             const marker = '<!-- build-preview-artifact -->';
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
             if (!process.env.ARTIFACT_URL) {
@@ -69,12 +77,18 @@ jobs:
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             const prNumber = context.payload.pull_request.number;
             const artifactName = `forecaswatch2-dev-pbw-pr-${prNumber}.zip`;
+            const memoryLogPath = process.env.MEMORY_LOG_PATH;
+            const memoryReport = memoryLogPath && fs.existsSync(memoryLogPath)
+              ? renderPebbleMemoryReport(parsePebbleMemoryReport(fs.readFileSync(memoryLogPath, 'utf8')))
+              : '_No memory usage log was captured for this run._';
 
             const body = [
               marker,
               '✅ Preview dev build available.',
               '',
               `Download [${artifactName}](${process.env.ARTIFACT_URL})`,
+              '',
+              memoryReport,
               '',
               'Artifacts are attached to the workflow run/job and require GitHub access to this repository.',
               `Run: [#${process.env.GITHUB_RUN_NUMBER}](${runUrl})`,

--- a/scripts/parse-pebble-memory-report.js
+++ b/scripts/parse-pebble-memory-report.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+
+const MEMORY_BLOCK_PATTERN =
+  /^(?<platform>[A-Z0-9_]+) APP MEMORY USAGE\s*\r?\nTotal size of resources:\s*(?<resources>[\d,]+) bytes \/ (?<resourcesCap>[^\r\n]+)\r?\nTotal footprint in RAM:\s*(?<ram>[\d,]+) bytes \/ (?<ramCap>[^\r\n]+)\r?\nFree RAM available \(heap\):\s*(?<free>[\d,]+) bytes$/gm;
+
+/**
+ * Parse Pebble SDK memory-usage blocks from build output.
+ *
+ * @param {string} logText Build log text.
+ * @returns {Array<{
+ *   platform: string,
+ *   resources: string,
+ *   resourcesCap: string,
+ *   ram: string,
+ *   ramCap: string,
+ *   free: string,
+ * }>} Parsed memory entries in log order.
+ */
+function parsePebbleMemoryReport(logText) {
+  const entries = [];
+
+  for (const match of logText.matchAll(MEMORY_BLOCK_PATTERN)) {
+    const groups = match.groups;
+
+    if (!groups) {
+      continue;
+    }
+
+    entries.push({
+      platform: groups.platform,
+      resources: groups.resources,
+      resourcesCap: groups.resourcesCap.trim(),
+      ram: groups.ram,
+      ramCap: groups.ramCap.trim(),
+      free: groups.free,
+    });
+  }
+
+  return entries;
+}
+
+/**
+ * Convert a Pebble platform name into a human-friendly label.
+ *
+ * @param {string} platform Pebble platform identifier.
+ * @returns {string} Human-friendly label.
+ */
+function humanizePlatform(platform) {
+  return platform.charAt(0) + platform.slice(1).toLowerCase();
+}
+
+/**
+ * Format a byte count for markdown output.
+ *
+ * @param {string} value Raw byte count from the build log.
+ * @returns {string} Human-friendly byte count.
+ */
+function formatBytes(value) {
+  return Number(value.replace(/,/g, '')).toLocaleString('en-US');
+}
+
+/**
+ * Format parsed Pebble memory entries as a markdown table.
+ *
+ * @param {Array<{
+ *   platform: string,
+ *   resources: string,
+ *   resourcesCap: string,
+ *   ram: string,
+ *   ramCap: string,
+ *   free: string,
+ * }>} entries Parsed memory entries.
+ * @returns {string} Markdown table or a fallback note.
+ */
+function renderPebbleMemoryReport(entries) {
+  if (!entries.length) {
+    return '_No memory usage blocks were found in the build log._';
+  }
+
+  const lines = [
+    '### Memory usage',
+    '',
+    '| Platform | Resources | RAM footprint | Free heap |',
+    '| --- | ---: | ---: | ---: |',
+  ];
+
+  for (const entry of entries) {
+    lines.push(
+      `| ${humanizePlatform(entry.platform)} | ${formatBytes(entry.resources)} bytes / ${entry.resourcesCap} | ${formatBytes(entry.ram)} bytes / ${entry.ramCap} | ${formatBytes(entry.free)} bytes |`
+    );
+  }
+
+  lines.push('', `Parsed ${entries.length} platform${entries.length === 1 ? '' : 's'} from the build log.`);
+
+  return lines.join('\n');
+}
+
+if (require.main === module) {
+  const inputPath = process.argv[2];
+
+  if (!inputPath) {
+    console.error('Usage: parse-pebble-memory-report.js <build-log-path>');
+    process.exit(1);
+  }
+
+  const logText = fs.readFileSync(inputPath, 'utf8');
+  process.stdout.write(renderPebbleMemoryReport(parsePebbleMemoryReport(logText)));
+}
+
+module.exports = {
+  humanizePlatform,
+  parsePebbleMemoryReport,
+  renderPebbleMemoryReport,
+};


### PR DESCRIPTION
• Capture Pebble build output in the preview workflow and parse the per-platform memory blocks into one PR comment.
• Keep the existing artifact link upsert and add a compact memory table for each target.

Verified locally with `mise build dev`.