### PR TITLE
fix(memory): remove loading overlay layer

### DIFF
--- a/src/c/appendix/app_message.c
+++ b/src/c/appendix/app_message.c
@@ -65,7 +65,6 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
         time_t *sun_event_times = (time_t*) (sun_events_tuple->value->data + 1);
         persist_set_sun_event_start_type(sun_event_start_type);
         persist_set_sun_event_times(sun_event_times, 2);
-        loading_layer_refresh();
         forecast_layer_refresh();
         weather_status_layer_refresh();
         calendar_layer_refresh();

--- a/src/c/appendix/app_message.c
+++ b/src/c/appendix/app_message.c
@@ -3,7 +3,6 @@
 #include "math.h"
 #include "c/layers/forecast_layer.h"
 #include "c/layers/weather_status_layer.h"
-#include "c/layers/loading_layer.h"
 #include "c/layers/calendar_layer.h"
 #include "c/layers/calendar_status_layer.h"
 #include "c/windows/main_window.h"

--- a/src/c/components/loading_component.c
+++ b/src/c/components/loading_component.c
@@ -1,0 +1,13 @@
+#include "loading_component.h"
+
+void loading_component_render(GContext *ctx, GRect bounds) {
+    graphics_context_set_fill_color(ctx, GColorBlack);
+    graphics_fill_rect(ctx, bounds, 0, GCornerNone);
+    graphics_context_set_text_color(ctx, GColorWhite);
+    graphics_draw_text(ctx, "No data :(",
+                       fonts_get_system_font(FONT_KEY_GOTHIC_18),
+                       GRect(0, bounds.size.h / 3, bounds.size.w, bounds.size.h),
+                       GTextOverflowModeWordWrap,
+                       GTextAlignmentCenter,
+                       NULL);
+}

--- a/src/c/components/loading_component.h
+++ b/src/c/components/loading_component.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <pebble.h>
+
+void loading_component_render(GContext *ctx, GRect bounds);

--- a/src/c/layers/forecast_layer.c
+++ b/src/c/layers/forecast_layer.c
@@ -3,6 +3,7 @@
 #include "c/appendix/math.h"
 #include "c/appendix/config.h"
 #include "c/appendix/memory_log.h"
+#include "loading_layer.h"
 
 #define LEFT_AXIS_LABEL_STRIP_MIN_W 15
 #define LEFT_AXIS_LABEL_TO_GRAPH_GAP 2
@@ -68,6 +69,19 @@ static GPoint s_points_precip[MAX_FORECAST_ENTRIES + 2];
 static GPath s_path_precip_area_under;
 static GPath s_path_precip_top;
 static GPath s_path_temp;
+
+static void draw_no_data_notice(GContext *ctx, GRect bounds)
+{
+    graphics_context_set_fill_color(ctx, GColorBlack);
+    graphics_fill_rect(ctx, bounds, 0, GCornerNone);
+    graphics_context_set_text_color(ctx, GColorWhite);
+    graphics_draw_text(ctx, "No data :(",
+                       fonts_get_system_font(FONT_KEY_GOTHIC_18),
+                       GRect(0, bounds.size.h / 3, bounds.size.w, bounds.size.h),
+                       GTextOverflowModeWordWrap,
+                       GTextAlignmentCenter,
+                       NULL);
+}
 
 static RenderSpec make_render_spec()
 {
@@ -461,10 +475,9 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
     const int raw_num_entries = persist_get_num_entries();
     const int num_entries = raw_num_entries > MAX_FORECAST_ENTRIES ? MAX_FORECAST_ENTRIES : raw_num_entries;
     MemoryHeapProbe redraw_probe = MEMORY_HEAP_PROBE_START("forecast_update");
-    if (num_entries < 2)
+    if (!loading_layer_has_valid_data() || num_entries < 2)
     {
-        graphics_context_set_fill_color(ctx, GColorBlack);
-        graphics_fill_rect(ctx, bounds, 0, GCornerNone);
+        draw_no_data_notice(ctx, bounds);
         MEMORY_LOG_HEAP("forecast_update:exit");
         return;
     }

--- a/src/c/layers/forecast_layer.c
+++ b/src/c/layers/forecast_layer.c
@@ -3,7 +3,7 @@
 #include "c/appendix/math.h"
 #include "c/appendix/config.h"
 #include "c/appendix/memory_log.h"
-#include "loading_layer.h"
+#include "c/components/loading_component.h"
 
 #define LEFT_AXIS_LABEL_STRIP_MIN_W 15
 #define LEFT_AXIS_LABEL_TO_GRAPH_GAP 2
@@ -70,19 +70,6 @@ static GPath s_path_precip_area_under;
 static GPath s_path_precip_top;
 static GPath s_path_temp;
 
-static void draw_no_data_notice(GContext *ctx, GRect bounds)
-{
-    graphics_context_set_fill_color(ctx, GColorBlack);
-    graphics_fill_rect(ctx, bounds, 0, GCornerNone);
-    graphics_context_set_text_color(ctx, GColorWhite);
-    graphics_draw_text(ctx, "No data :(",
-                       fonts_get_system_font(FONT_KEY_GOTHIC_18),
-                       GRect(0, bounds.size.h / 3, bounds.size.w, bounds.size.h),
-                       GTextOverflowModeWordWrap,
-                       GTextAlignmentCenter,
-                       NULL);
-}
-
 static RenderSpec make_render_spec()
 {
     RenderSpec spec = {
@@ -95,6 +82,19 @@ static RenderSpec make_render_spec()
     }
 
     return spec;
+}
+
+bool forecast_layer_has_valid_data()
+{
+    const time_t forecast_start = persist_get_forecast_start();
+    const time_t now = time(NULL);
+
+    return now - forecast_start <= 60 * 60 * 12;
+}
+
+static bool forecast_should_show_loading_state(int num_entries)
+{
+    return num_entries < 2 || !forecast_layer_has_valid_data();
 }
 
 static ForecastLayout compute_layout(GRect bounds)
@@ -475,9 +475,9 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
     const int raw_num_entries = persist_get_num_entries();
     const int num_entries = raw_num_entries > MAX_FORECAST_ENTRIES ? MAX_FORECAST_ENTRIES : raw_num_entries;
     MemoryHeapProbe redraw_probe = MEMORY_HEAP_PROBE_START("forecast_update");
-    if (!loading_layer_has_valid_data() || num_entries < 2)
+    if (forecast_should_show_loading_state(num_entries))
     {
-        draw_no_data_notice(ctx, bounds);
+        loading_component_render(ctx, bounds);
         MEMORY_LOG_HEAP("forecast_update:exit");
         return;
     }

--- a/src/c/layers/forecast_layer.h
+++ b/src/c/layers/forecast_layer.h
@@ -4,6 +4,8 @@
 
 void forecast_layer_create(Layer *parent_layer, GRect frame);
 
+bool forecast_layer_has_valid_data();
+
 void forecast_layer_refresh();
 
 void forecast_layer_destroy();

--- a/src/c/layers/loading_layer.c
+++ b/src/c/layers/loading_layer.c
@@ -1,55 +1,9 @@
 #include "loading_layer.h"
 #include "c/appendix/persist.h"
-#include "c/appendix/memory_log.h"
-
-static Layer *s_loading_layer;
-static TextLayer *s_loading_text_layer;
 
 bool loading_layer_has_valid_data() {
     const time_t forecast_start = persist_get_forecast_start();
     const time_t now = time(NULL);
 
     return now - forecast_start <= 60 * 60 * 12;
-}
-
-static void loading_update_proc(Layer *layer, GContext *ctx) {
-    GRect bounds = layer_get_bounds(layer);
-    int w = bounds.size.w;
-    int h = bounds.size.h;
-
-    // Black out the weather components
-    graphics_context_set_fill_color(ctx, GColorBlack);
-    graphics_fill_rect(ctx, GRect(0, 0, w, h), 0, GCornerNone);
-}
-
-void loading_layer_create(Layer* parent_layer, GRect frame) {
-    s_loading_layer = layer_create(frame);
-
-    GRect bounds = layer_get_bounds(s_loading_layer);
-    int w = bounds.size.w; int h = bounds.size.h;
-    s_loading_text_layer = text_layer_create(GRect(0, h / 3, w, h));
-    text_layer_set_background_color(s_loading_text_layer, GColorClear);
-    text_layer_set_text_color(s_loading_text_layer, GColorWhite);
-    text_layer_set_font(s_loading_text_layer, fonts_get_system_font(FONT_KEY_GOTHIC_18));
-    text_layer_set_text_alignment(s_loading_text_layer, GTextAlignmentCenter);
-    text_layer_set_text(s_loading_text_layer, "No data :(");
-
-    layer_set_update_proc(s_loading_layer, loading_update_proc);
-    layer_add_child(s_loading_layer, text_layer_get_layer(s_loading_text_layer));
-    layer_add_child(parent_layer, s_loading_layer);
-    MEMORY_LOG_HEAP("after_loading_layer_create");
-}
-
-void loading_layer_refresh() {
-    if (loading_layer_has_valid_data())
-        layer_set_hidden(s_loading_layer, true);
-    else
-        layer_set_hidden(s_loading_layer, false); // show the no data notice
-}
-
-void loading_layer_destroy() {
-    MEMORY_LOG_HEAP("loading_layer_destroy:before");
-    text_layer_destroy(s_loading_text_layer);
-    layer_destroy(s_loading_layer);
-    MEMORY_LOG_HEAP("loading_layer_destroy:after");
 }

--- a/src/c/layers/loading_layer.c
+++ b/src/c/layers/loading_layer.c
@@ -1,9 +1,0 @@
-#include "loading_layer.h"
-#include "c/appendix/persist.h"
-
-bool loading_layer_has_valid_data() {
-    const time_t forecast_start = persist_get_forecast_start();
-    const time_t now = time(NULL);
-
-    return now - forecast_start <= 60 * 60 * 12;
-}

--- a/src/c/layers/loading_layer.h
+++ b/src/c/layers/loading_layer.h
@@ -1,5 +1,0 @@
-#pragma once
-
-#include <pebble.h>
-
-bool loading_layer_has_valid_data();

--- a/src/c/layers/loading_layer.h
+++ b/src/c/layers/loading_layer.h
@@ -2,10 +2,4 @@
 
 #include <pebble.h>
 
-void loading_layer_create(Layer* parent_layer, GRect frame);
-
 bool loading_layer_has_valid_data();
-
-void loading_layer_refresh();
-
-void loading_layer_destroy();

--- a/src/c/windows/main_window.c
+++ b/src/c/windows/main_window.c
@@ -36,9 +36,6 @@ static void main_window_load(Window *window) {
             GRect(0, CALENDAR_STATUS_HEIGHT, bounds.size.w, CALENDAR_HEIGHT));
     calendar_status_layer_create(window_layer,
             GRect(0, 0, bounds.size.w, CALENDAR_STATUS_HEIGHT + 1));  // +1 to stop text clipping
-    loading_layer_create(window_layer,
-            GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, w, FORECAST_HEIGHT + WEATHER_STATUS_HEIGHT));
-    loading_layer_refresh();
     app_message_send_startup_state(loading_layer_has_valid_data());
     MEMORY_LOG_HEAP("after_window_load");
 }
@@ -50,7 +47,6 @@ static void main_window_unload(Window *window) {
     forecast_layer_destroy();
     calendar_layer_destroy();
     calendar_status_layer_destroy();
-    loading_layer_destroy();
     MEMORY_LOG_HEAP("after_window_unload");
 }
 
@@ -62,7 +58,7 @@ static void minute_handler(struct tm *tick_time, TimeUnits units_changed) {
         calendar_status_layer_refresh();
     }
     status_icons_refresh();
-    loading_layer_refresh();
+    forecast_layer_refresh();
 }
 
 /*----------------------------

--- a/src/c/windows/main_window.c
+++ b/src/c/windows/main_window.c
@@ -4,9 +4,7 @@
 #include "c/layers/weather_status_layer.h"
 #include "c/layers/calendar_layer.h"
 #include "c/layers/calendar_status_layer.h"
-#include "c/layers/loading_layer.h"
 #include "c/appendix/app_message.h"
-#include "c/appendix/persist.h"
 #include "c/appendix/memory_log.h"
 
 #define FORECAST_HEIGHT 51
@@ -36,7 +34,7 @@ static void main_window_load(Window *window) {
             GRect(0, CALENDAR_STATUS_HEIGHT, bounds.size.w, CALENDAR_HEIGHT));
     calendar_status_layer_create(window_layer,
             GRect(0, 0, bounds.size.w, CALENDAR_STATUS_HEIGHT + 1));  // +1 to stop text clipping
-    app_message_send_startup_state(loading_layer_has_valid_data());
+    app_message_send_startup_state(forecast_layer_has_valid_data());
     MEMORY_LOG_HEAP("after_window_load");
 }
 


### PR DESCRIPTION
- Draw the no-data state from a render-only loading component instead of keeping a separate Pebble loading overlay layer.
- Establish the component pattern under src/c/components while keeping forecast_layer responsible for composition/state decisions.
- mise build passes; latest Aplite RAM footprint is 17,088 B vs 17,312 B before (+224 B free heap).
