### PR TITLE
feat: pebble time 2 (emery) support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,11 @@ If you need runtime logs, `mise install-emulator --logs` runs it in an emulator 
 - Prefer drawing directly in an update proc over creating extra layer objects when a simple render path is enough.
 - If a UI element only exists to paint pixels, keep it as light as possible instead of modeling it as a full layer.
 
-## JavaScript Conventions
+## Code Conventions
 
 - For new JavaScript functions, add brief JSDoc (`@param`/`@returns`) annotations since this project does not use TypeScript.
 - Prefer `Boolean(value)` over `!!value` in new/edited code for readability.
+- When branching on `#ifdef PBL_PLATFORM_EMERY`, add a brief `emery:` comment explaining the Emery-specific behavior.
 
 ## Supabase migrations
 

--- a/package.template.json
+++ b/package.template.json
@@ -18,7 +18,8 @@
     "targetPlatforms": [
       "aplite",
       "basalt",
-      "diorite"
+      "diorite",
+      "emery"
     ],
     "watchapp": {
       "watchface": true

--- a/src/c/appendix/config.c
+++ b/src/c/appendix/config.c
@@ -98,16 +98,42 @@ int config_n_today() {
 }
 
 GFont config_time_font() {
-    const char *font_keys[] = {
-        [TIME_FONT_ROBOTO] = FONT_KEY_ROBOTO_BOLD_SUBSET_49,
-        [TIME_FONT_LECO] = FONT_KEY_LECO_42_NUMBERS,
-        [TIME_FONT_BITHAM] = FONT_KEY_BITHAM_42_MEDIUM_NUMBERS
-    };
+    const char *font_key = FONT_KEY_ROBOTO_BOLD_SUBSET_49;
     int16_t font_index = g_config->time_font;
-    const int16_t font_count = (int16_t)(sizeof(font_keys) / sizeof(font_keys[0]));
-    if (font_index < 0 || font_index >= font_count)
+
+    if (font_index < 0 || font_index > TIME_FONT_BITHAM) {
         font_index = TIME_FONT_ROBOTO;
-    return fonts_get_system_font(font_keys[font_index]);
+    }
+
+#ifdef PBL_PLATFORM_EMERY
+    switch (font_index) {
+        case TIME_FONT_LECO:
+            font_key = FONT_KEY_LECO_60_NUMBERS_AM_PM;
+            break;
+        case TIME_FONT_BITHAM:
+            font_key = FONT_KEY_BITHAM_42_MEDIUM_NUMBERS;
+            break;
+        case TIME_FONT_ROBOTO:
+        default:
+            font_key = FONT_KEY_ROBOTO_BOLD_SUBSET_49;
+            break;
+    }
+#else
+    switch (font_index) {
+        case TIME_FONT_LECO:
+            font_key = FONT_KEY_LECO_42_NUMBERS;
+            break;
+        case TIME_FONT_BITHAM:
+            font_key = FONT_KEY_BITHAM_42_MEDIUM_NUMBERS;
+            break;
+        case TIME_FONT_ROBOTO:
+        default:
+            font_key = FONT_KEY_ROBOTO_BOLD_SUBSET_49;
+            break;
+    }
+#endif
+
+    return fonts_get_system_font(font_key);
 }
 
 bool config_highlight_holidays() {

--- a/src/c/appendix/config.c
+++ b/src/c/appendix/config.c
@@ -98,8 +98,7 @@ int config_n_today() {
 }
 
 GFont config_time_font() {
-    int16_t font_index = g_config->time_font;
-    static const char *font_keys[] = {
+    const char *font_keys[] = {
         [TIME_FONT_ROBOTO] = FONT_KEY_ROBOTO_BOLD_SUBSET_49,
 #ifdef PBL_PLATFORM_EMERY
         // emery: use larger LECO font size
@@ -109,11 +108,10 @@ GFont config_time_font() {
 #endif
         [TIME_FONT_BITHAM] = FONT_KEY_BITHAM_42_MEDIUM_NUMBERS
     };
-
-    if (font_index < 0 || font_index > TIME_FONT_BITHAM) {
+    int16_t font_index = g_config->time_font;
+    const int16_t font_count = (int16_t)(sizeof(font_keys) / sizeof(font_keys[0]));
+    if (font_index < 0 || font_index >= font_count)
         font_index = TIME_FONT_ROBOTO;
-    }
-
     return fonts_get_system_font(font_keys[font_index]);
 }
 

--- a/src/c/appendix/config.c
+++ b/src/c/appendix/config.c
@@ -114,9 +114,7 @@ GFont config_time_font() {
         font_index = TIME_FONT_ROBOTO;
     }
 
-    const char *font_key = font_keys[font_index];
-
-    return fonts_get_system_font(font_key);
+    return fonts_get_system_font(font_keys[font_index]);
 }
 
 bool config_highlight_holidays() {

--- a/src/c/appendix/config.c
+++ b/src/c/appendix/config.c
@@ -101,7 +101,12 @@ GFont config_time_font() {
     int16_t font_index = g_config->time_font;
     static const char *font_keys[] = {
         [TIME_FONT_ROBOTO] = FONT_KEY_ROBOTO_BOLD_SUBSET_49,
+#ifdef PBL_PLATFORM_EMERY
+        // emery: use larger LECO font size
+        [TIME_FONT_LECO] = FONT_KEY_LECO_60_NUMBERS_AM_PM,
+#else
         [TIME_FONT_LECO] = FONT_KEY_LECO_42_NUMBERS,
+#endif
         [TIME_FONT_BITHAM] = FONT_KEY_BITHAM_42_MEDIUM_NUMBERS
     };
 
@@ -110,12 +115,6 @@ GFont config_time_font() {
     }
 
     const char *font_key = font_keys[font_index];
-#ifdef PBL_PLATFORM_EMERY
-    // emery: use larger LECO numerals to preserve legibility on the 200x228 display.
-    if (font_index == TIME_FONT_LECO) {
-        font_key = FONT_KEY_LECO_60_NUMBERS_AM_PM;
-    }
-#endif
 
     return fonts_get_system_font(font_key);
 }

--- a/src/c/appendix/config.c
+++ b/src/c/appendix/config.c
@@ -98,38 +98,22 @@ int config_n_today() {
 }
 
 GFont config_time_font() {
-    const char *font_key = FONT_KEY_ROBOTO_BOLD_SUBSET_49;
     int16_t font_index = g_config->time_font;
+    static const char *font_keys[] = {
+        [TIME_FONT_ROBOTO] = FONT_KEY_ROBOTO_BOLD_SUBSET_49,
+        [TIME_FONT_LECO] = FONT_KEY_LECO_42_NUMBERS,
+        [TIME_FONT_BITHAM] = FONT_KEY_BITHAM_42_MEDIUM_NUMBERS
+    };
 
     if (font_index < 0 || font_index > TIME_FONT_BITHAM) {
         font_index = TIME_FONT_ROBOTO;
     }
 
+    const char *font_key = font_keys[font_index];
 #ifdef PBL_PLATFORM_EMERY
-    switch (font_index) {
-        case TIME_FONT_LECO:
-            font_key = FONT_KEY_LECO_60_NUMBERS_AM_PM;
-            break;
-        case TIME_FONT_BITHAM:
-            font_key = FONT_KEY_BITHAM_42_MEDIUM_NUMBERS;
-            break;
-        case TIME_FONT_ROBOTO:
-        default:
-            font_key = FONT_KEY_ROBOTO_BOLD_SUBSET_49;
-            break;
-    }
-#else
-    switch (font_index) {
-        case TIME_FONT_LECO:
-            font_key = FONT_KEY_LECO_42_NUMBERS;
-            break;
-        case TIME_FONT_BITHAM:
-            font_key = FONT_KEY_BITHAM_42_MEDIUM_NUMBERS;
-            break;
-        case TIME_FONT_ROBOTO:
-        default:
-            font_key = FONT_KEY_ROBOTO_BOLD_SUBSET_49;
-            break;
+    // emery: use larger LECO numerals to preserve legibility on the 200x228 display.
+    if (font_index == TIME_FONT_LECO) {
+        font_key = FONT_KEY_LECO_60_NUMBERS_AM_PM;
     }
 #endif
 

--- a/src/c/layers/calendar_layer.c
+++ b/src/c/layers/calendar_layer.c
@@ -6,14 +6,39 @@
 #define NUM_WEEKS 3
 #define DAYS_PER_WEEK 7
 #define FONT_OFFSET 5
+#define EMERY_CALENDAR_TEXT_SHIFT_Y 5
+#define EMERY_CALENDAR_TEXT_SHIFT_X 1
+
+#ifdef PBL_PLATFORM_EMERY
+#define CALENDAR_FONT_KEY FONT_KEY_GOTHIC_24
+#define CALENDAR_FONT_KEY_BOLD FONT_KEY_GOTHIC_24_BOLD
+#else
+#define CALENDAR_FONT_KEY FONT_KEY_GOTHIC_18
+#define CALENDAR_FONT_KEY_BOLD FONT_KEY_GOTHIC_18_BOLD
+#endif
 
 static Layer *s_calendar_layer;
 
 static GRect calendar_cell_rect(GRect bounds, int i) {
     float box_w = (float) bounds.size.w / DAYS_PER_WEEK;
     float box_h = (float) bounds.size.h / NUM_WEEKS;
-    return GRect((i % DAYS_PER_WEEK) * box_w, (i / DAYS_PER_WEEK) * box_h - FONT_OFFSET,
-                 box_w, box_h + FONT_OFFSET);
+    return GRect((i % DAYS_PER_WEEK) * box_w, (i / DAYS_PER_WEEK) * box_h,
+                 box_w, box_h);
+}
+
+static GRect calendar_text_rect(GRect cell_rect, const char *text, GFont font, bool is_emery) {
+    if (!is_emery) {
+        return GRect(cell_rect.origin.x,
+                     cell_rect.origin.y - FONT_OFFSET,
+                     cell_rect.size.w,
+                     cell_rect.size.h + FONT_OFFSET);
+    }
+
+    const GRect measure_box = GRect(0, 0, cell_rect.size.w, cell_rect.size.h);
+    const GSize text_size = graphics_text_layout_get_content_size(
+        text, font, measure_box, GTextOverflowModeFill, GTextAlignmentCenter);
+    const int text_top = cell_rect.origin.y + (cell_rect.size.h - text_size.h) / 2 - EMERY_CALENDAR_TEXT_SHIFT_Y;
+    return GRect(cell_rect.origin.x - EMERY_CALENDAR_TEXT_SHIFT_X, text_top, cell_rect.size.w, text_size.h);
 }
 
 /* Copy struct tm out of localtime's static buffer — see localtime(3). */
@@ -100,6 +125,11 @@ static GColor today_color() {
 
 static void calendar_update_proc(Layer *layer, GContext *ctx) {
     GRect bounds = layer_get_bounds(layer);
+#ifdef PBL_PLATFORM_EMERY
+    const bool is_emery = true;
+#else
+    const bool is_emery = false;
+#endif
     int w = bounds.size.w;
     int h = bounds.size.h;
     float box_w = (float) w / DAYS_PER_WEEK;
@@ -122,12 +152,14 @@ static void calendar_update_proc(Layer *layer, GContext *ctx) {
         GColor text_color = (i == i_today) ? gcolor_legible_over(today_color())
                                            : PBL_IF_COLOR_ELSE(date_color(&t), GColorWhite);
         char buffer[4];
+        GFont font = fonts_get_system_font(bold ? CALENDAR_FONT_KEY_BOLD : CALENDAR_FONT_KEY);
+        GRect cell_rect = calendar_cell_rect(bounds, i);
 
         graphics_context_set_text_color(ctx, text_color);
         graphics_draw_text(ctx,
             (snprintf(buffer, sizeof(buffer), "%d", t.tm_mday), buffer),
-            fonts_get_system_font(bold ? FONT_KEY_GOTHIC_18_BOLD : FONT_KEY_GOTHIC_18),
-            calendar_cell_rect(bounds, i), GTextOverflowModeFill, GTextAlignmentCenter, NULL);
+            font,
+            calendar_text_rect(cell_rect, buffer, font, is_emery), GTextOverflowModeFill, GTextAlignmentCenter, NULL);
     }
 }
 

--- a/src/c/layers/calendar_layer.c
+++ b/src/c/layers/calendar_layer.c
@@ -26,6 +26,16 @@ static GRect calendar_cell_rect(GRect bounds, int i) {
                  box_w, box_h);
 }
 
+// Apply a tiny Emery-only horizontal tweak for two-digit dates that start with "1"
+// to ensure they stay visually centered within calendar boxes.
+static int emery_calendar_text_shift_x(const char *text) {
+    if (text[1] != '\0' && text[0] == '1') {
+        return EMERY_CALENDAR_TEXT_SHIFT_X;
+    }
+
+    return 0;
+}
+
 static GRect calendar_text_rect(GRect cell_rect, const char *text, GFont font, bool is_emery) {
     if (!is_emery) {
         return GRect(cell_rect.origin.x,
@@ -38,7 +48,7 @@ static GRect calendar_text_rect(GRect cell_rect, const char *text, GFont font, b
     const GSize text_size = graphics_text_layout_get_content_size(
         text, font, measure_box, GTextOverflowModeFill, GTextAlignmentCenter);
     const int text_top = cell_rect.origin.y + (cell_rect.size.h - text_size.h) / 2 - EMERY_CALENDAR_TEXT_SHIFT_Y;
-    return GRect(cell_rect.origin.x - EMERY_CALENDAR_TEXT_SHIFT_X, text_top, cell_rect.size.w, text_size.h);
+    return GRect(cell_rect.origin.x - emery_calendar_text_shift_x(text), text_top, cell_rect.size.w, text_size.h);
 }
 
 /* Copy struct tm out of localtime's static buffer — see localtime(3). */

--- a/src/c/layers/calendar_layer.c
+++ b/src/c/layers/calendar_layer.c
@@ -27,6 +27,7 @@ static GRect calendar_cell_rect(GRect bounds, int i) {
                  box_w, box_h);
 }
 
+#ifdef PBL_PLATFORM_EMERY
 // Apply a tiny Emery-only horizontal tweak for two-digit dates that start with "1"
 // to ensure they stay visually centered within calendar boxes.
 static int emery_calendar_text_shift_x(const char *text) {
@@ -36,15 +37,10 @@ static int emery_calendar_text_shift_x(const char *text) {
 
     return 0;
 }
+#endif
 
-static GRect calendar_text_rect(GRect cell_rect, const char *text, GFont font, bool is_emery) {
-    if (!is_emery) {
-        return GRect(cell_rect.origin.x,
-                     cell_rect.origin.y - FONT_OFFSET,
-                     cell_rect.size.w,
-                     cell_rect.size.h + FONT_OFFSET);
-    }
-
+#ifdef PBL_PLATFORM_EMERY
+static GRect calendar_text_rect(GRect cell_rect, const char *text, GFont font) {
     // emery: measure real glyph bounds and vertically center text in each date cell.
     const GRect measure_box = GRect(0, 0, cell_rect.size.w, cell_rect.size.h);
     const GSize text_size = graphics_text_layout_get_content_size(
@@ -52,6 +48,16 @@ static GRect calendar_text_rect(GRect cell_rect, const char *text, GFont font, b
     const int text_top = cell_rect.origin.y + (cell_rect.size.h - text_size.h) / 2 - EMERY_CALENDAR_TEXT_SHIFT_Y;
     return GRect(cell_rect.origin.x - emery_calendar_text_shift_x(text), text_top, cell_rect.size.w, text_size.h);
 }
+#else
+static GRect calendar_text_rect(GRect cell_rect, const char *text, GFont font) {
+    (void)text;
+    (void)font;
+    return GRect(cell_rect.origin.x,
+                 cell_rect.origin.y - FONT_OFFSET,
+                 cell_rect.size.w,
+                 cell_rect.size.h + FONT_OFFSET);
+}
+#endif
 
 /* Copy struct tm out of localtime's static buffer — see localtime(3). */
 static struct tm relative_tm(int days_from_today)
@@ -137,12 +143,6 @@ static GColor today_color() {
 
 static void calendar_update_proc(Layer *layer, GContext *ctx) {
     GRect bounds = layer_get_bounds(layer);
-    // emery: switch to center-by-measurement text placement instead of legacy offset placement.
-#ifdef PBL_PLATFORM_EMERY
-    const bool is_emery = true;
-#else
-    const bool is_emery = false;
-#endif
     int w = bounds.size.w;
     int h = bounds.size.h;
     float box_w = (float) w / DAYS_PER_WEEK;
@@ -172,7 +172,7 @@ static void calendar_update_proc(Layer *layer, GContext *ctx) {
         graphics_draw_text(ctx,
             (snprintf(buffer, sizeof(buffer), "%d", t.tm_mday), buffer),
             font,
-            calendar_text_rect(cell_rect, buffer, font, is_emery), GTextOverflowModeFill, GTextAlignmentCenter, NULL);
+            calendar_text_rect(cell_rect, buffer, font), GTextOverflowModeFill, GTextAlignmentCenter, NULL);
     }
 }
 

--- a/src/c/layers/calendar_layer.c
+++ b/src/c/layers/calendar_layer.c
@@ -9,6 +9,7 @@
 #define EMERY_CALENDAR_TEXT_SHIFT_Y 5
 #define EMERY_CALENDAR_TEXT_SHIFT_X 1
 
+// emery: render calendar dates with larger fonts
 #ifdef PBL_PLATFORM_EMERY
 #define CALENDAR_FONT_KEY FONT_KEY_GOTHIC_24
 #define CALENDAR_FONT_KEY_BOLD FONT_KEY_GOTHIC_24_BOLD
@@ -44,6 +45,7 @@ static GRect calendar_text_rect(GRect cell_rect, const char *text, GFont font, b
                      cell_rect.size.h + FONT_OFFSET);
     }
 
+    // emery: measure real glyph bounds and vertically center text in each date cell.
     const GRect measure_box = GRect(0, 0, cell_rect.size.w, cell_rect.size.h);
     const GSize text_size = graphics_text_layout_get_content_size(
         text, font, measure_box, GTextOverflowModeFill, GTextAlignmentCenter);
@@ -135,6 +137,7 @@ static GColor today_color() {
 
 static void calendar_update_proc(Layer *layer, GContext *ctx) {
     GRect bounds = layer_get_bounds(layer);
+    // emery: switch to center-by-measurement text placement instead of legacy offset placement.
 #ifdef PBL_PLATFORM_EMERY
     const bool is_emery = true;
 #else

--- a/src/c/layers/calendar_status_layer.c
+++ b/src/c/layers/calendar_status_layer.c
@@ -8,6 +8,14 @@
 #define PADDING 4
 #define ICON_SLOT_1 GRect(PADDING, 0, 10, 10)
 #define ICON_SLOT_2 GRect(PADDING * 2 + 10, 0, 10, 10)
+// emery: center icons in the taller status row.
+#ifdef PBL_PLATFORM_EMERY
+#define STATUS_ICON_Y(bounds_h, icon_h) (((bounds_h) - (icon_h)) / 2)
+#define BATTERY_Y(bounds_h) (((bounds_h) - BATTERY_H) / 2)
+#else
+#define STATUS_ICON_Y(bounds_h, icon_h) ((void)(bounds_h), (void)(icon_h), 0)
+#define BATTERY_Y(bounds_h) ((void)(bounds_h), 1)
+#endif
 
 static Layer *s_calendar_status_layer;
 // emery: draw month text in update proc instead of maintaining a dedicated TextLayer.
@@ -112,16 +120,16 @@ static void calendar_status_update_proc(Layer *layer, GContext *ctx) {
 
     if (show_qt) {
         ensure_mute_bitmap_loaded();
-        draw_bitmap(ctx, s_mute_bitmap, GRect(ICON_SLOT_1.origin.x, (bounds.size.h - ICON_SLOT_1.size.h) / 2,
+        draw_bitmap(ctx, s_mute_bitmap, GRect(ICON_SLOT_1.origin.x, STATUS_ICON_Y(bounds.size.h, ICON_SLOT_1.size.h),
                                               ICON_SLOT_1.size.w, ICON_SLOT_1.size.h));
     }
 
     if (show_bt) {
         ensure_bt_bitmap_loaded();
-        draw_bitmap(ctx, s_bt_bitmap, GRect(icon_x, (bounds.size.h - 10) / 2, 10, 10));
+        draw_bitmap(ctx, s_bt_bitmap, GRect(icon_x, STATUS_ICON_Y(bounds.size.h, 10), 10, 10));
     } else if (show_bt_disconnect) {
         ensure_bt_disconnect_bitmap_loaded();
-        draw_bitmap(ctx, s_bt_disconnect_bitmap, GRect(icon_x, (bounds.size.h - 10) / 2, 10, 10));
+        draw_bitmap(ctx, s_bt_disconnect_bitmap, GRect(icon_x, STATUS_ICON_Y(bounds.size.h, 10), 10, 10));
     }
 }
 
@@ -162,7 +170,7 @@ void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
     MEMORY_HEAP_PROBE_SAMPLE("after_update_proc_set", &probe);
 
     battery_layer_create(s_calendar_status_layer,
-                         GRect(w - BATTERY_W - PADDING, (bounds.size.h - BATTERY_H) / 2, BATTERY_W, BATTERY_H));
+                         GRect(w - BATTERY_W - PADDING, BATTERY_Y(bounds.size.h), BATTERY_W, BATTERY_H));
     MEMORY_HEAP_PROBE_SAMPLE("after_battery_layer_create", &probe);
 
     layer_add_child(parent_layer, s_calendar_status_layer);

--- a/src/c/layers/calendar_status_layer.c
+++ b/src/c/layers/calendar_status_layer.c
@@ -10,6 +10,7 @@
 #define ICON_SLOT_2 GRect(PADDING * 2 + 10, 0, 10, 10)
 
 static Layer *s_calendar_status_layer;
+// emery: draw month text in update proc instead of maintaining a dedicated TextLayer.
 #ifndef PBL_PLATFORM_EMERY
 static TextLayer *s_calendar_month_layer;
 #endif
@@ -21,6 +22,7 @@ static GColor s_bt_palette[2];
 static GColor s_bt_disconnect_palette[2];
 static GColor s_mute_palette[2];
 
+// emery: vertically center month text using measured height to match taller status bar.
 #ifdef PBL_PLATFORM_EMERY
 static GRect month_text_rect(GRect bounds, GFont font) {
     const GRect measure_box = GRect(0, 0, bounds.size.w, bounds.size.h);
@@ -95,6 +97,7 @@ static void calendar_status_update_proc(Layer *layer, GContext *ctx) {
     maybe_unload_calendar_status_bitmaps(show_qt, connected);
 
     graphics_context_set_text_color(ctx, GColorWhite);
+    // emery: render month text directly with a larger font in the status layer draw pass.
 #ifdef PBL_PLATFORM_EMERY
     const GFont month_font = fonts_get_system_font(FONT_KEY_GOTHIC_24);
     graphics_draw_text(
@@ -131,6 +134,7 @@ void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
     GRect bounds = layer_get_bounds(s_calendar_status_layer);
     int w = bounds.size.w;
 
+    // emery: skip month TextLayer creation because month is drawn directly in update proc.
 #ifndef PBL_PLATFORM_EMERY
     // Set up month text layer
     s_calendar_month_layer = text_layer_create(GRect(0, -7, w, 25));
@@ -148,6 +152,7 @@ void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
     MEMORY_HEAP_PROBE_SAMPLE("after_connection_subscribe", &probe);
 
     calendar_status_layer_refresh();
+    // emery: do not attach month TextLayer since Emery uses direct text drawing.
 #ifndef PBL_PLATFORM_EMERY
     layer_add_child(s_calendar_status_layer, text_layer_get_layer(s_calendar_month_layer));
     MEMORY_HEAP_PROBE_SAMPLE("after_month_child_added", &probe);
@@ -193,6 +198,7 @@ void calendar_status_layer_refresh() {
     time_t now = time(NULL);
     struct tm *tm_now = localtime(&now);
     strftime(s_calendar_month_text, sizeof(s_calendar_month_text), "%b %Y", tm_now);
+    // emery: avoid text_layer_set_text because Emery month text comes from custom drawing.
 #ifndef PBL_PLATFORM_EMERY
     text_layer_set_text(s_calendar_month_layer, s_calendar_month_text);
 #endif

--- a/src/c/layers/calendar_status_layer.c
+++ b/src/c/layers/calendar_status_layer.c
@@ -3,7 +3,6 @@
 #include "c/appendix/config.h"
 #include "c/appendix/memory_log.h"
 
-#define MONTH_FONT_OFFSET 7
 #define BATTERY_W 29
 #define BATTERY_H 10
 #define PADDING 4
@@ -11,14 +10,26 @@
 #define ICON_SLOT_2 GRect(PADDING * 2 + 10, 0, 10, 10)
 
 static Layer *s_calendar_status_layer;
+#ifndef PBL_PLATFORM_EMERY
 static TextLayer *s_calendar_month_layer;
-static TextLayer *s_calendar_month_layer;
+#endif
+static char s_calendar_month_text[10];
 static GBitmap *s_mute_bitmap;
 static GBitmap *s_bt_bitmap;
 static GBitmap *s_bt_disconnect_bitmap;
 static GColor s_bt_palette[2];
 static GColor s_bt_disconnect_palette[2];
 static GColor s_mute_palette[2];
+
+#ifdef PBL_PLATFORM_EMERY
+static GRect month_text_rect(GRect bounds, GFont font) {
+    const GRect measure_box = GRect(0, 0, bounds.size.w, bounds.size.h);
+    const GSize text_size = graphics_text_layout_get_content_size(
+        s_calendar_month_text, font, measure_box, GTextOverflowModeFill, GTextAlignmentCenter);
+    const int text_y = ((bounds.size.h - text_size.h) / 2) - 5;
+    return GRect(0, text_y, bounds.size.w, text_size.h + 3);
+}
+#endif
 
 static void draw_bitmap(GContext *ctx, GBitmap *bitmap, GRect frame) {
     graphics_context_set_compositing_mode(ctx, GCompOpSet);
@@ -74,6 +85,7 @@ static void maybe_unload_calendar_status_bitmaps(bool show_qt, bool connected) {
 }
 
 static void calendar_status_update_proc(Layer *layer, GContext *ctx) {
+    GRect bounds = layer_get_bounds(layer);
     bool show_qt = show_qt_icon();
     bool connected = connection_service_peek_pebble_app_connection();
     int icon_x = show_qt ? ICON_SLOT_2.origin.x : ICON_SLOT_1.origin.x;
@@ -82,17 +94,31 @@ static void calendar_status_update_proc(Layer *layer, GContext *ctx) {
 
     maybe_unload_calendar_status_bitmaps(show_qt, connected);
 
+    graphics_context_set_text_color(ctx, GColorWhite);
+#ifdef PBL_PLATFORM_EMERY
+    const GFont month_font = fonts_get_system_font(FONT_KEY_GOTHIC_24);
+    graphics_draw_text(
+        ctx,
+        s_calendar_month_text,
+        month_font,
+        month_text_rect(bounds, month_font),
+        GTextOverflowModeFill,
+        GTextAlignmentCenter,
+        NULL);
+#endif
+
     if (show_qt) {
         ensure_mute_bitmap_loaded();
-        draw_bitmap(ctx, s_mute_bitmap, ICON_SLOT_1);
+        draw_bitmap(ctx, s_mute_bitmap, GRect(ICON_SLOT_1.origin.x, (bounds.size.h - ICON_SLOT_1.size.h) / 2,
+                                              ICON_SLOT_1.size.w, ICON_SLOT_1.size.h));
     }
 
     if (show_bt) {
         ensure_bt_bitmap_loaded();
-        draw_bitmap(ctx, s_bt_bitmap, GRect(icon_x, 0, 10, 10));
+        draw_bitmap(ctx, s_bt_bitmap, GRect(icon_x, (bounds.size.h - 10) / 2, 10, 10));
     } else if (show_bt_disconnect) {
         ensure_bt_disconnect_bitmap_loaded();
-        draw_bitmap(ctx, s_bt_disconnect_bitmap, GRect(icon_x, 0, 10, 10));
+        draw_bitmap(ctx, s_bt_disconnect_bitmap, GRect(icon_x, (bounds.size.h - 10) / 2, 10, 10));
     }
 }
 
@@ -105,13 +131,15 @@ void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
     GRect bounds = layer_get_bounds(s_calendar_status_layer);
     int w = bounds.size.w;
 
+#ifndef PBL_PLATFORM_EMERY
     // Set up month text layer
-    s_calendar_month_layer = text_layer_create(GRect(0, -MONTH_FONT_OFFSET, w, 25));
+    s_calendar_month_layer = text_layer_create(GRect(0, -7, w, 25));
     text_layer_set_background_color(s_calendar_month_layer, GColorClear);
     text_layer_set_text_alignment(s_calendar_month_layer, GTextAlignmentCenter);
     text_layer_set_text_color(s_calendar_month_layer, GColorWhite);
     text_layer_set_font(s_calendar_month_layer, fonts_get_system_font(FONT_KEY_GOTHIC_18));
     MEMORY_HEAP_PROBE_SAMPLE("after_month_text_layer", &probe);
+#endif
 
     // Set up bluetooth handler
     connection_service_subscribe((ConnectionHandlers) {
@@ -120,13 +148,16 @@ void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
     MEMORY_HEAP_PROBE_SAMPLE("after_connection_subscribe", &probe);
 
     calendar_status_layer_refresh();
+#ifndef PBL_PLATFORM_EMERY
     layer_add_child(s_calendar_status_layer, text_layer_get_layer(s_calendar_month_layer));
     MEMORY_HEAP_PROBE_SAMPLE("after_month_child_added", &probe);
+#endif
 
     layer_set_update_proc(s_calendar_status_layer, calendar_status_update_proc);
     MEMORY_HEAP_PROBE_SAMPLE("after_update_proc_set", &probe);
 
-    battery_layer_create(s_calendar_status_layer, GRect(w - BATTERY_W - PADDING, 1, BATTERY_W, BATTERY_H));
+    battery_layer_create(s_calendar_status_layer,
+                         GRect(w - BATTERY_W - PADDING, (bounds.size.h - BATTERY_H) / 2, BATTERY_W, BATTERY_H));
     MEMORY_HEAP_PROBE_SAMPLE("after_battery_layer_create", &probe);
 
     layer_add_child(parent_layer, s_calendar_status_layer);
@@ -159,12 +190,12 @@ void status_icons_refresh() {
 }
 
 void calendar_status_layer_refresh() {
-    static char s_buffer_month[10];
     time_t now = time(NULL);
     struct tm *tm_now = localtime(&now);
-
-    strftime(s_buffer_month, sizeof(s_buffer_month), "%b %Y", tm_now);
-    text_layer_set_text(s_calendar_month_layer, s_buffer_month);
+    strftime(s_calendar_month_text, sizeof(s_calendar_month_text), "%b %Y", tm_now);
+#ifndef PBL_PLATFORM_EMERY
+    text_layer_set_text(s_calendar_month_layer, s_calendar_month_text);
+#endif
     status_icons_refresh();
 }
 

--- a/src/c/layers/calendar_status_layer.c
+++ b/src/c/layers/calendar_status_layer.c
@@ -6,22 +6,21 @@
 #define BATTERY_W 29
 #define BATTERY_H 10
 #define PADDING 4
+#define MONTH_FONT_OFFSET 7
 #define ICON_SLOT_1 GRect(PADDING, 0, 10, 10)
 #define ICON_SLOT_2 GRect(PADDING * 2 + 10, 0, 10, 10)
 // emery: center icons in the taller status row.
 #ifdef PBL_PLATFORM_EMERY
 #define STATUS_ICON_Y(bounds_h, icon_h) (((bounds_h) - (icon_h)) / 2)
 #define BATTERY_Y(bounds_h) (((bounds_h) - BATTERY_H) / 2)
+#define MONTH_FONT_KEY FONT_KEY_GOTHIC_24
 #else
 #define STATUS_ICON_Y(bounds_h, icon_h) ((void)(bounds_h), (void)(icon_h), 0)
 #define BATTERY_Y(bounds_h) ((void)(bounds_h), 1)
+#define MONTH_FONT_KEY FONT_KEY_GOTHIC_18
 #endif
 
 static Layer *s_calendar_status_layer;
-// emery: draw month text in update proc instead of maintaining a dedicated TextLayer.
-#ifndef PBL_PLATFORM_EMERY
-static TextLayer *s_calendar_month_layer;
-#endif
 static char s_calendar_month_text[10];
 static GBitmap *s_mute_bitmap;
 static GBitmap *s_bt_bitmap;
@@ -30,16 +29,32 @@ static GColor s_bt_palette[2];
 static GColor s_bt_disconnect_palette[2];
 static GColor s_mute_palette[2];
 
-// emery: vertically center month text using measured height to match taller status bar.
-#ifdef PBL_PLATFORM_EMERY
 static GRect month_text_rect(GRect bounds, GFont font) {
+#ifdef PBL_PLATFORM_EMERY
+    // emery: vertically center month text using measured height to match taller status bar.
     const GRect measure_box = GRect(0, 0, bounds.size.w, bounds.size.h);
     const GSize text_size = graphics_text_layout_get_content_size(
         s_calendar_month_text, font, measure_box, GTextOverflowModeFill, GTextAlignmentCenter);
     const int text_y = ((bounds.size.h - text_size.h) / 2) - 5;
     return GRect(0, text_y, bounds.size.w, text_size.h + 3);
-}
+#else
+    (void)font;
+    return GRect(0, -MONTH_FONT_OFFSET, bounds.size.w, 25);
 #endif
+}
+
+static void draw_month_text(GContext *ctx, GRect bounds) {
+    const GFont month_font = fonts_get_system_font(MONTH_FONT_KEY);
+    graphics_context_set_text_color(ctx, GColorWhite);
+    graphics_draw_text(
+        ctx,
+        s_calendar_month_text,
+        month_font,
+        month_text_rect(bounds, month_font),
+        GTextOverflowModeFill,
+        GTextAlignmentCenter,
+        NULL);
+}
 
 static void draw_bitmap(GContext *ctx, GBitmap *bitmap, GRect frame) {
     graphics_context_set_compositing_mode(ctx, GCompOpSet);
@@ -104,20 +119,6 @@ static void calendar_status_update_proc(Layer *layer, GContext *ctx) {
 
     maybe_unload_calendar_status_bitmaps(show_qt, connected);
 
-    graphics_context_set_text_color(ctx, GColorWhite);
-    // emery: render month text directly with a larger font in the status layer draw pass.
-#ifdef PBL_PLATFORM_EMERY
-    const GFont month_font = fonts_get_system_font(FONT_KEY_GOTHIC_24);
-    graphics_draw_text(
-        ctx,
-        s_calendar_month_text,
-        month_font,
-        month_text_rect(bounds, month_font),
-        GTextOverflowModeFill,
-        GTextAlignmentCenter,
-        NULL);
-#endif
-
     if (show_qt) {
         ensure_mute_bitmap_loaded();
         draw_bitmap(ctx, s_mute_bitmap, GRect(ICON_SLOT_1.origin.x, STATUS_ICON_Y(bounds.size.h, ICON_SLOT_1.size.h),
@@ -131,6 +132,8 @@ static void calendar_status_update_proc(Layer *layer, GContext *ctx) {
         ensure_bt_disconnect_bitmap_loaded();
         draw_bitmap(ctx, s_bt_disconnect_bitmap, GRect(icon_x, STATUS_ICON_Y(bounds.size.h, 10), 10, 10));
     }
+
+    draw_month_text(ctx, bounds);
 }
 
 void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
@@ -142,17 +145,6 @@ void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
     GRect bounds = layer_get_bounds(s_calendar_status_layer);
     int w = bounds.size.w;
 
-    // emery: skip month TextLayer creation because month is drawn directly in update proc.
-#ifndef PBL_PLATFORM_EMERY
-    // Set up month text layer
-    s_calendar_month_layer = text_layer_create(GRect(0, -7, w, 25));
-    text_layer_set_background_color(s_calendar_month_layer, GColorClear);
-    text_layer_set_text_alignment(s_calendar_month_layer, GTextAlignmentCenter);
-    text_layer_set_text_color(s_calendar_month_layer, GColorWhite);
-    text_layer_set_font(s_calendar_month_layer, fonts_get_system_font(FONT_KEY_GOTHIC_18));
-    MEMORY_HEAP_PROBE_SAMPLE("after_month_text_layer", &probe);
-#endif
-
     // Set up bluetooth handler
     connection_service_subscribe((ConnectionHandlers) {
         .pebble_app_connection_handler = bluetooth_callback
@@ -160,11 +152,6 @@ void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
     MEMORY_HEAP_PROBE_SAMPLE("after_connection_subscribe", &probe);
 
     calendar_status_layer_refresh();
-    // emery: do not attach month TextLayer since Emery uses direct text drawing.
-#ifndef PBL_PLATFORM_EMERY
-    layer_add_child(s_calendar_status_layer, text_layer_get_layer(s_calendar_month_layer));
-    MEMORY_HEAP_PROBE_SAMPLE("after_month_child_added", &probe);
-#endif
 
     layer_set_update_proc(s_calendar_status_layer, calendar_status_update_proc);
     MEMORY_HEAP_PROBE_SAMPLE("after_update_proc_set", &probe);
@@ -206,10 +193,6 @@ void calendar_status_layer_refresh() {
     time_t now = time(NULL);
     struct tm *tm_now = localtime(&now);
     strftime(s_calendar_month_text, sizeof(s_calendar_month_text), "%b %Y", tm_now);
-    // emery: avoid text_layer_set_text because Emery month text comes from custom drawing.
-#ifndef PBL_PLATFORM_EMERY
-    text_layer_set_text(s_calendar_month_layer, s_calendar_month_text);
-#endif
     status_icons_refresh();
 }
 

--- a/src/c/layers/forecast_layer.c
+++ b/src/c/layers/forecast_layer.c
@@ -15,6 +15,13 @@
 #define LABEL_PADDING 20          // Minimum width a label should cover
 #define BOTTOM_AXIS_H 10          // Height of the bottom axis (hour labels)
 #define MARGIN_TEMP_H 7           // Height of margins for the temperature plot
+#ifdef PBL_PLATFORM_EMERY
+#define FORECAST_BOTTOM_PAD 10
+#define EMERY_AXIS_LABEL_TOP 6
+#define EMERY_AXIS_LABEL_H 14
+#else
+#define FORECAST_BOTTOM_PAD 0
+#endif
 #define NIGHT_HATCH_SPACING PBL_IF_COLOR_ELSE(6, 7)
 #define NIGHT_HATCH_COLOR GColorDarkGray
 #define PRECIP_FILL_COLOR PBL_IF_COLOR_ELSE(GColorCobaltBlue, GColorLightGray)
@@ -86,7 +93,7 @@ static RenderSpec make_render_spec()
 static ForecastLayout compute_layout(GRect bounds)
 {
     ForecastLayout layout;
-    layout.graph_bounds = GRect(s_axis_left_w, 0, bounds.size.w - s_axis_left_w, bounds.size.h);
+    layout.graph_bounds = GRect(s_axis_left_w, 0, bounds.size.w - s_axis_left_w, bounds.size.h - FORECAST_BOTTOM_PAD);
     layout.graph_plot_rect = GRect(layout.graph_bounds.origin.x, 0, layout.graph_bounds.size.w, layout.graph_bounds.size.h - BOTTOM_AXIS_H);
     layout.w = layout.graph_bounds.size.w;
     layout.h = layout.graph_bounds.size.h;
@@ -446,6 +453,8 @@ static void draw_night_boundaries_over_precip(GContext *ctx, GRect graph_plot_re
     }
 }
 
+static GSize temp_label_string_size(const char *text);
+
 static void forecast_update_proc(Layer *layer, GContext *ctx)
 {
     MEMORY_LOG_HEAP("forecast_update:enter");
@@ -498,8 +507,12 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
     graphics_context_set_text_color(ctx, GColorWhite);
     graphics_context_set_stroke_color(ctx, GColorLightGray);
 
+#ifdef PBL_PLATFORM_EMERY
+    const int entries_per_label = 3;
+#else
     // Round this division up by adding (divisor - 1) to the dividend
     const int entries_per_label = ((float)LABEL_PADDING + (entry_w - 1)) / entry_w;
+#endif
     for (int i = 0; i < num_entries; ++i)
     {
         int entry_x = graph_bounds.origin.x + i * entry_w;
@@ -518,26 +531,68 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
         }
         s_points_temp[i] = GPoint(entry_x, h - temp_h - MARGIN_TEMP_H - BOTTOM_AXIS_H);
 
-        if (i % entries_per_label == 0)
+#ifdef PBL_PLATFORM_EMERY
+        const bool is_label_tick = (i % entries_per_label) == 0;
+        const GColor tick_color = is_label_tick ? GColorLightGray : GColorDarkGray;
+        graphics_context_set_stroke_width(ctx, 1);
+        graphics_context_set_stroke_color(ctx, tick_color);
+        graphics_draw_line(ctx,
+                           GPoint(entry_x, h - BOTTOM_AXIS_H - 0),
+                           GPoint(entry_x, h - BOTTOM_AXIS_H + (is_label_tick ? 6 : 4)));
+#endif
+    }
+
+#ifndef PBL_PLATFORM_EMERY
+    for (int label_i = 0; label_i < num_entries; label_i += entries_per_label)
+    {
+        const int label_x = graph_bounds.origin.x + (int)(label_i * entry_w);
+        char buf[4];
+
+        snprintf(buf, sizeof(buf), "%d", config_axis_hour(forecast_start_local->tm_hour + label_i));
+#ifdef PBL_PLATFORM_EMERY
+        const int label_y = h - BOTTOM_AXIS_H + EMERY_AXIS_LABEL_TOP;
+        const int label_h = EMERY_AXIS_LABEL_H;
+#else
+        const int label_y = h - BOTTOM_AXIS_H - BOTTOM_AXIS_FONT_OFFSET;
+        const int label_h = BOTTOM_AXIS_H;
+#endif
+        graphics_draw_text(ctx, buf,
+                           fonts_get_system_font(FONT_KEY_GOTHIC_14),
+                           GRect(label_x - 20, label_y, 40, label_h),
+                           GTextOverflowModeWordWrap,
+                           GTextAlignmentCenter,
+                           NULL);
+
+        const int next_label_i = label_i + entries_per_label;
+        if (next_label_i < num_entries)
         {
-            // Draw a text hour label at the appropriate interval
-            char buf[4];
-            snprintf(buf, sizeof(buf), "%d", config_axis_hour(forecast_start_local->tm_hour + i));
-            graphics_draw_text(ctx, buf,
-                               fonts_get_system_font(FONT_KEY_GOTHIC_14),
-                               GRect(entry_x - 20, h - BOTTOM_AXIS_H - BOTTOM_AXIS_FONT_OFFSET, 40, BOTTOM_AXIS_H),
-                               GTextOverflowModeWordWrap,
-                               GTextAlignmentCenter,
-                               NULL);
-        }
-        else if ((i + entries_per_label / 2) % entries_per_label == 0)
-        {
-            // Just draw a tick between hour labels
-            graphics_draw_line(ctx,
-                               GPoint(entry_x, h - BOTTOM_AXIS_H - 0),
-                               GPoint(entry_x, h - BOTTOM_AXIS_H + 4));
+            for (int tick_offset = 1; tick_offset < entries_per_label; ++tick_offset)
+            {
+                const float tick_x_f = graph_bounds.origin.x + ((label_i + tick_offset) * entry_w);
+                int tick_x = (int)(tick_x_f + 0.5f);
+                graphics_draw_line(ctx,
+                                   GPoint(tick_x, h - BOTTOM_AXIS_H - 0),
+                                   GPoint(tick_x, h - BOTTOM_AXIS_H + 4));
+            }
         }
     }
+#else
+    for (int label_i = 0; label_i < num_entries; label_i += entries_per_label)
+    {
+        const int label_x = graph_bounds.origin.x + (int)(label_i * entry_w);
+        char buf[4];
+
+        snprintf(buf, sizeof(buf), "%d", config_axis_hour(forecast_start_local->tm_hour + label_i));
+        const int label_y = h - BOTTOM_AXIS_H + EMERY_AXIS_LABEL_TOP;
+        const int label_h = EMERY_AXIS_LABEL_H;
+        graphics_draw_text(ctx, buf,
+                           fonts_get_system_font(FONT_KEY_GOTHIC_14),
+                           GRect(label_x - 20, label_y, 40, label_h),
+                           GTextOverflowModeWordWrap,
+                           GTextAlignmentCenter,
+                           NULL);
+    }
+#endif
 
     // Complete the area under the precipitation
     s_points_precip[num_entries] = GPoint(graph_bounds.origin.x + w, h - BOTTOM_AXIS_H);
@@ -587,13 +642,22 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
     graphics_fill_rect(ctx, GRect(0, 0, s_axis_left_w, h - BOTTOM_AXIS_H), 0, GCornerNone); // Paint over plot bleeding
     graphics_draw_line(ctx, GPoint(graph_bounds.origin.x, 0), GPoint(graph_bounds.origin.x, axis_y));
     graphics_context_set_text_color(ctx, GColorWhite);
+    GSize hi_size = temp_label_string_size(s_buffer_hi);
+    GSize lo_size = temp_label_string_size(s_buffer_lo);
+#ifdef PBL_PLATFORM_EMERY
+    const int hi_y = 0;
+    const int lo_y = axis_y - lo_size.h - 2;
+#else
+    const int hi_y = -3;
+    const int lo_y = 22;
+#endif
     graphics_draw_text(ctx, s_buffer_hi,
                        fonts_get_system_font(FONT_KEY_GOTHIC_18),
-                       GRect(0, -3, s_label_strip_w, TEMP_LABEL_H),
+                       GRect(0, hi_y, s_label_strip_w, hi_size.h),
                        GTextOverflowModeFill, GTextAlignmentRight, NULL);
     graphics_draw_text(ctx, s_buffer_lo,
                        fonts_get_system_font(FONT_KEY_GOTHIC_18),
-                       GRect(0, 22, s_label_strip_w, TEMP_LABEL_H),
+                       GRect(0, lo_y, s_label_strip_w, lo_size.h),
                        GTextOverflowModeFill, GTextAlignmentRight, NULL);
     MEMORY_HEAP_PROBE_LOG_MIN(&redraw_probe);
     MEMORY_LOG_HEAP("forecast_update:exit");
@@ -606,6 +670,14 @@ static int temp_label_string_width(const char *text)
     const GSize sz = graphics_text_layout_get_content_size(text, font, box, GTextOverflowModeFill,
                                                            GTextAlignmentRight);
     return sz.w;
+}
+
+static GSize temp_label_string_size(const char *text)
+{
+    const GFont font = fonts_get_system_font(FONT_KEY_GOTHIC_18);
+    const GRect box = GRect(0, 0, TEMP_LABEL_MEASURE_BOX_W, TEMP_LABEL_MEASURE_BOX_H);
+    return graphics_text_layout_get_content_size(text, font, box, GTextOverflowModeFill,
+                                                 GTextAlignmentRight);
 }
 
 static void text_labels_refresh()
@@ -633,7 +705,6 @@ static void text_labels_refresh()
     {
         s_axis_left_w = graph_inset_w;
     }
-
 }
 
 void forecast_layer_create(Layer *parent_layer, GRect frame)

--- a/src/c/layers/forecast_layer.c
+++ b/src/c/layers/forecast_layer.c
@@ -15,6 +15,7 @@
 #define LABEL_PADDING 20          // Minimum width a label should cover
 #define BOTTOM_AXIS_H 10          // Height of the bottom axis (hour labels)
 #define MARGIN_TEMP_H 7           // Height of margins for the temperature plot
+// emery: reserve extra bottom space for larger hour labels and tick marks.
 #ifdef PBL_PLATFORM_EMERY
 #define FORECAST_BOTTOM_PAD 10
 #define EMERY_AXIS_LABEL_TOP 6
@@ -507,6 +508,7 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
     graphics_context_set_text_color(ctx, GColorWhite);
     graphics_context_set_stroke_color(ctx, GColorLightGray);
 
+    // emery: reduce label density to every 3 points so the wider labels do not overlap.
 #ifdef PBL_PLATFORM_EMERY
     const int entries_per_label = 3;
 #else
@@ -531,6 +533,7 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
         }
         s_points_temp[i] = GPoint(entry_x, h - temp_h - MARGIN_TEMP_H - BOTTOM_AXIS_H);
 
+        // emery: draw emphasized major/minor bottom-axis ticks for improved readability.
 #ifdef PBL_PLATFORM_EMERY
         const bool is_label_tick = (i % entries_per_label) == 0;
         const GColor tick_color = is_label_tick ? GColorLightGray : GColorDarkGray;
@@ -542,6 +545,7 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
 #endif
     }
 
+// non-emery: draw labels with classic font-offset positioning and midpoint ticks.
 #ifndef PBL_PLATFORM_EMERY
     for (int label_i = 0; label_i < num_entries; label_i += entries_per_label)
     {
@@ -549,13 +553,8 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
         char buf[4];
 
         snprintf(buf, sizeof(buf), "%d", config_axis_hour(forecast_start_local->tm_hour + label_i));
-#ifdef PBL_PLATFORM_EMERY
-        const int label_y = h - BOTTOM_AXIS_H + EMERY_AXIS_LABEL_TOP;
-        const int label_h = EMERY_AXIS_LABEL_H;
-#else
         const int label_y = h - BOTTOM_AXIS_H - BOTTOM_AXIS_FONT_OFFSET;
         const int label_h = BOTTOM_AXIS_H;
-#endif
         graphics_draw_text(ctx, buf,
                            fonts_get_system_font(FONT_KEY_GOTHIC_14),
                            GRect(label_x - 20, label_y, 40, label_h),
@@ -576,6 +575,7 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
             }
         }
     }
+// emery: draw labels lower in the reserved pad and skip midpoint tick loop.
 #else
     for (int label_i = 0; label_i < num_entries; label_i += entries_per_label)
     {
@@ -644,6 +644,7 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
     graphics_context_set_text_color(ctx, GColorWhite);
     GSize hi_size = temp_label_string_size(s_buffer_hi);
     GSize lo_size = temp_label_string_size(s_buffer_lo);
+    // emery: anchor hi/lo labels to the top/bottom of the axis strip to avoid clipping.
 #ifdef PBL_PLATFORM_EMERY
     const int hi_y = 0;
     const int lo_y = axis_y - lo_size.h - 2;

--- a/src/c/layers/forecast_layer.c
+++ b/src/c/layers/forecast_layer.c
@@ -12,15 +12,16 @@
 #define TEMP_LABEL_MEASURE_BOX_W 200
 #define TEMP_LABEL_MEASURE_BOX_H 40
 #define BOTTOM_AXIS_FONT_OFFSET 4 // Adjustment for whitespace at top of font
-#define LABEL_PADDING 20          // Minimum width a label should cover
 #define BOTTOM_AXIS_H 10          // Height of the bottom axis (hour labels)
 #define MARGIN_TEMP_H 7           // Height of margins for the temperature plot
 // emery: reserve extra bottom space for larger hour labels and tick marks.
 #ifdef PBL_PLATFORM_EMERY
+#define HOUR_LABEL_MIN_SPACING 24 // Minimum horizontal spacing for hour labels
 #define FORECAST_BOTTOM_PAD 10
 #define EMERY_AXIS_LABEL_TOP 6
 #define EMERY_AXIS_LABEL_H 14
 #else
+#define HOUR_LABEL_MIN_SPACING 20 // Minimum horizontal spacing for hour labels
 #define FORECAST_BOTTOM_PAD 0
 #endif
 #define NIGHT_HATCH_SPACING PBL_IF_COLOR_ELSE(6, 7)
@@ -508,13 +509,8 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
     graphics_context_set_text_color(ctx, GColorWhite);
     graphics_context_set_stroke_color(ctx, GColorLightGray);
 
-    // emery: reduce label density to every 3 points so the wider labels do not overlap.
-#ifdef PBL_PLATFORM_EMERY
-    const int entries_per_label = 3;
-#else
-    // Round this division up by adding (divisor - 1) to the dividend
-    const int entries_per_label = ((float)LABEL_PADDING + (entry_w - 1)) / entry_w;
-#endif
+    // Round this division up by adding (divisor - 1) to the dividend.
+    const int entries_per_label = ((float)HOUR_LABEL_MIN_SPACING + (entry_w - 1)) / entry_w;
     for (int i = 0; i < num_entries; ++i)
     {
         int entry_x = graph_bounds.origin.x + i * entry_w;

--- a/src/c/layers/forecast_layer.c
+++ b/src/c/layers/forecast_layer.c
@@ -563,16 +563,14 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
                            NULL);
 
         const int next_label_i = label_i + entries_per_label;
-        if (next_label_i < num_entries)
+        const int midpoint_i = label_i + entries_per_label / 2;
+        if (next_label_i < num_entries && midpoint_i > label_i && midpoint_i < next_label_i)
         {
-            for (int tick_offset = 1; tick_offset < entries_per_label; ++tick_offset)
-            {
-                const float tick_x_f = graph_bounds.origin.x + ((label_i + tick_offset) * entry_w);
-                int tick_x = (int)(tick_x_f + 0.5f);
-                graphics_draw_line(ctx,
-                                   GPoint(tick_x, h - BOTTOM_AXIS_H - 0),
-                                   GPoint(tick_x, h - BOTTOM_AXIS_H + 4));
-            }
+            const float tick_x_f = graph_bounds.origin.x + (midpoint_i * entry_w);
+            const int tick_x = (int)(tick_x_f + 0.5f);
+            graphics_draw_line(ctx,
+                               GPoint(tick_x, h - BOTTOM_AXIS_H - 0),
+                               GPoint(tick_x, h - BOTTOM_AXIS_H + 4));
         }
     }
 // emery: draw labels lower in the reserved pad and skip midpoint tick loop.

--- a/src/c/layers/forecast_layer.c
+++ b/src/c/layers/forecast_layer.c
@@ -562,8 +562,7 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
         const int midpoint_i = label_i + entries_per_label / 2;
         if (midpoint_i > label_i && midpoint_i < next_label_i && midpoint_i < num_entries)
         {
-            const float tick_x_f = graph_bounds.origin.x + (midpoint_i * entry_w);
-            const int tick_x = (int)(tick_x_f + 0.5f);
+            const int tick_x = graph_bounds.origin.x + (int)(midpoint_i * entry_w);
             graphics_draw_line(ctx,
                                GPoint(tick_x, h - BOTTOM_AXIS_H - 0),
                                GPoint(tick_x, h - BOTTOM_AXIS_H + 4));

--- a/src/c/layers/forecast_layer.c
+++ b/src/c/layers/forecast_layer.c
@@ -564,7 +564,7 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
 
         const int next_label_i = label_i + entries_per_label;
         const int midpoint_i = label_i + entries_per_label / 2;
-        if (next_label_i < num_entries && midpoint_i > label_i && midpoint_i < next_label_i)
+        if (midpoint_i > label_i && midpoint_i < next_label_i && midpoint_i < num_entries)
         {
             const float tick_x_f = graph_bounds.origin.x + (midpoint_i * entry_w);
             const int tick_x = (int)(tick_x_f + 0.5f);

--- a/src/c/layers/time_layer.c
+++ b/src/c/layers/time_layer.c
@@ -5,6 +5,8 @@
 // MT = Margin Top
 #define MT_TIME 14
 #define MT_AM_PM 7
+#define MT_TIME_LECO 2
+#define MT_AM_PM_LECO 2
 
 
 static TextLayer *s_container_layer;
@@ -71,10 +73,23 @@ void time_layer_tick() {
     int text_top = -MT_TIME + (bounds.size.h/2 - text_h/2);
     int text_left = bounds.size.w / 2 - content_w / 2;
 
+#ifdef PBL_PLATFORM_EMERY
+    if (g_config->time_font == TIME_FONT_LECO) {
+        text_top -= MT_TIME_LECO;
+    }
+#endif
+
     // Update layer positions and visibility
     text_layer_move_frame(s_time_layer, GRect(text_left, text_top, content_w, time_size.h));
-    if (g_config->show_am_pm)
-        text_layer_move_frame(s_am_pm_layer, GRect(time_size.w, MT_TIME - MT_AM_PM, 30, time_size.h));
+    if (g_config->show_am_pm) {
+        int am_pm_y = MT_TIME - MT_AM_PM;
+#ifdef PBL_PLATFORM_EMERY
+        if (g_config->time_font == TIME_FONT_LECO) {
+            am_pm_y += MT_AM_PM_LECO;
+        }
+#endif
+        text_layer_move_frame(s_am_pm_layer, GRect(time_size.w, am_pm_y, 30, time_size.h));
+    }
     layer_set_hidden(text_layer_get_layer(s_am_pm_layer), !g_config->show_am_pm);
 }
 

--- a/src/c/layers/time_layer.c
+++ b/src/c/layers/time_layer.c
@@ -73,6 +73,7 @@ void time_layer_tick() {
     int text_top = -MT_TIME + (bounds.size.h/2 - text_h/2);
     int text_left = bounds.size.w / 2 - content_w / 2;
 
+    // emery: nudge LECO time text upward slightly to keep optical centering.
 #ifdef PBL_PLATFORM_EMERY
     if (g_config->time_font == TIME_FONT_LECO) {
         text_top -= MT_TIME_LECO;
@@ -83,6 +84,7 @@ void time_layer_tick() {
     text_layer_move_frame(s_time_layer, GRect(text_left, text_top, content_w, time_size.h));
     if (g_config->show_am_pm) {
         int am_pm_y = MT_TIME - MT_AM_PM;
+        // emery: nudge LECO AM/PM down slightly to align with larger time numerals.
 #ifdef PBL_PLATFORM_EMERY
         if (g_config->time_font == TIME_FONT_LECO) {
             am_pm_y += MT_AM_PM_LECO;

--- a/src/c/layers/weather_status_layer.c
+++ b/src/c/layers/weather_status_layer.c
@@ -6,11 +6,23 @@
 #define FONT_18_OFFSET 7
 #define FONT_14_OFFSET 3
 #define CITY_INIT_WIDTH 100
+#define MARGIN 2
+
+#ifdef PBL_PLATFORM_EMERY
+#define CITY_FONT_KEY FONT_KEY_GOTHIC_18
+#define SUN_EVENT_FONT_KEY FONT_KEY_GOTHIC_18
+#define ARROW_H 10
+#define ARROW_HEAD_H 4
+#define ARROW_HEAD_W 3
+#define ARROW_W 8
+#else
+#define CITY_FONT_KEY FONT_KEY_GOTHIC_14
+#define SUN_EVENT_FONT_KEY FONT_KEY_GOTHIC_14
 #define ARROW_H 8
 #define ARROW_HEAD_H 3
 #define ARROW_HEAD_W 2
 #define ARROW_W 6
-#define MARGIN 2
+#endif
 
 static GRect frame_curr_temp;
 static GRect frame_sun_event;
@@ -48,9 +60,14 @@ static void city_layer_refresh() {
     GRect bounds = layer_get_bounds(s_weather_status_layer);
     GSize size = text_layer_get_content_size(s_city_layer);
     int x = frame_curr_temp.origin.x + frame_curr_temp.size.w + MARGIN * 2;
-    int y = -FONT_14_OFFSET;
+    int y;
+#ifdef PBL_PLATFORM_EMERY
+    y = -FONT_18_OFFSET;
+#else
+    y = -FONT_14_OFFSET;
+#endif
     int w = bounds.size.w - frame_curr_temp.size.w - frame_sun_event.size.w - MARGIN * 4;
-    int h = size.h + FONT_14_OFFSET;
+    int h = size.h;
     text_layer_move_frame(s_city_layer, GRect(x, y, w, h));
 }
 
@@ -83,9 +100,15 @@ static void sun_event_layer_refresh() {
     // Dynamic resizing
     text_layer_move_frame(s_next_sun_event_layer, GRect(0, 0, 100, 100));  // Make it big so content doesn't get clipped
     GSize size = text_layer_get_content_size(s_next_sun_event_layer);
+    int y;
+#ifdef PBL_PLATFORM_EMERY
+    y = -FONT_18_OFFSET;
+#else
+    y = -FONT_14_OFFSET;
+#endif
     text_layer_move_frame(s_next_sun_event_layer,
-        GRect(bounds.size.w - MARGIN - ARROW_W - size.w, -FONT_14_OFFSET, size.w + ARROW_W, size.h));
-    frame_sun_event = GRect(bounds.size.w - MARGIN - ARROW_W - size.w, -FONT_14_OFFSET, size.w + ARROW_W + MARGIN, size.h);
+        GRect(bounds.size.w - MARGIN - ARROW_W - size.w, y, size.w + ARROW_W, size.h));
+    frame_sun_event = GRect(bounds.size.w - MARGIN - ARROW_W - size.w, y, size.w + ARROW_W + MARGIN, size.h);
 }
 
 static void weather_status_layer_init(GRect bounds) {
@@ -104,14 +127,14 @@ static void weather_status_layer_init(GRect bounds) {
     text_layer_set_background_color(s_city_layer, GColorClear);
     text_layer_set_text_alignment(s_city_layer, GTextAlignmentCenter);
     text_layer_set_text_color(s_city_layer, GColorWhite);
-    text_layer_set_font(s_city_layer, fonts_get_system_font(FONT_KEY_GOTHIC_14));
+    text_layer_set_font(s_city_layer, fonts_get_system_font(CITY_FONT_KEY));
 
     // Time of next sun event (sunrise/sunset)
     s_next_sun_event_layer = text_layer_create(GRect(w - MARGIN - 6 - 40, 4 - FONT_18_OFFSET, 40, 25));
     text_layer_set_background_color(s_next_sun_event_layer, GColorClear);
     text_layer_set_text_alignment(s_next_sun_event_layer, GTextAlignmentLeft);
     text_layer_set_text_color(s_next_sun_event_layer, GColorWhite);
-    text_layer_set_font(s_next_sun_event_layer, fonts_get_system_font(FONT_KEY_GOTHIC_14));
+    text_layer_set_font(s_next_sun_event_layer, fonts_get_system_font(SUN_EVENT_FONT_KEY));
 
     current_temp_layer_refresh();
     sun_event_layer_refresh();
@@ -132,7 +155,11 @@ static void weather_status_update_proc(Layer *layer, GContext *ctx) {
     } else {
         gpath_rotate_to(s_arrow_path, 0);
     }
+#ifdef PBL_PLATFORM_EMERY
+    gpath_move_to(s_arrow_path, GPoint(w - 4, bounds.size.h - (ARROW_H / 2) - 4));
+#else
     gpath_move_to(s_arrow_path, GPoint(w - 4, 6));
+#endif
     graphics_context_set_stroke_color(ctx, GColorWhite);
     gpath_draw_outline_open(ctx, s_arrow_path);
     graphics_context_set_fill_color(ctx, GColorWhite);

--- a/src/c/layers/weather_status_layer.c
+++ b/src/c/layers/weather_status_layer.c
@@ -62,14 +62,16 @@ static void city_layer_refresh() {
     GSize size = text_layer_get_content_size(s_city_layer);
     int x = frame_curr_temp.origin.x + frame_curr_temp.size.w + MARGIN * 2;
     int y;
+    int h;
     // emery: align city text baseline with 18px font metrics instead of 14px metrics.
 #ifdef PBL_PLATFORM_EMERY
     y = -FONT_18_OFFSET;
+    h = size.h + FONT_18_OFFSET;
 #else
     y = -FONT_14_OFFSET;
+    h = size.h + FONT_14_OFFSET;
 #endif
     int w = bounds.size.w - frame_curr_temp.size.w - frame_sun_event.size.w - MARGIN * 4;
-    int h = size.h;
     text_layer_move_frame(s_city_layer, GRect(x, y, w, h));
 }
 

--- a/src/c/layers/weather_status_layer.c
+++ b/src/c/layers/weather_status_layer.c
@@ -8,6 +8,7 @@
 #define CITY_INIT_WIDTH 100
 #define MARGIN 2
 
+// emery: use larger text and arrow geometry
 #ifdef PBL_PLATFORM_EMERY
 #define CITY_FONT_KEY FONT_KEY_GOTHIC_18
 #define SUN_EVENT_FONT_KEY FONT_KEY_GOTHIC_18
@@ -61,6 +62,7 @@ static void city_layer_refresh() {
     GSize size = text_layer_get_content_size(s_city_layer);
     int x = frame_curr_temp.origin.x + frame_curr_temp.size.w + MARGIN * 2;
     int y;
+    // emery: align city text baseline with 18px font metrics instead of 14px metrics.
 #ifdef PBL_PLATFORM_EMERY
     y = -FONT_18_OFFSET;
 #else
@@ -101,6 +103,7 @@ static void sun_event_layer_refresh() {
     text_layer_move_frame(s_next_sun_event_layer, GRect(0, 0, 100, 100));  // Make it big so content doesn't get clipped
     GSize size = text_layer_get_content_size(s_next_sun_event_layer);
     int y;
+    // emery: align sun-event text baseline with 18px font metrics instead of 14px metrics.
 #ifdef PBL_PLATFORM_EMERY
     y = -FONT_18_OFFSET;
 #else
@@ -155,6 +158,7 @@ static void weather_status_update_proc(Layer *layer, GContext *ctx) {
     } else {
         gpath_rotate_to(s_arrow_path, 0);
     }
+    // emery: place arrow lower so it is vertically centered in the taller status row.
 #ifdef PBL_PLATFORM_EMERY
     gpath_move_to(s_arrow_path, GPoint(w - 4, bounds.size.h - (ARROW_H / 2) - 4));
 #else

--- a/src/c/windows/main_window.c
+++ b/src/c/windows/main_window.c
@@ -26,6 +26,8 @@
 static Window *s_main_window;
 
 #ifdef PBL_PLATFORM_EMERY
+// emery: scale the main content bands proportionally to fill the taller screen
+// while preserving the legacy calendar/time/forecast balance.
 static void compute_content_layout(int content_h, int *calendar_h, int *time_h, int *forecast_h) {
     const int weight_sum = CALENDAR_HEIGHT + TIME_HEIGHT + FORECAST_HEIGHT;
 
@@ -39,21 +41,16 @@ static void main_window_load(Window *window) {
     // Get information about the Window
     Layer *window_layer = window_get_root_layer(window);
     GRect bounds = layer_get_bounds(window_layer);
+    int w = bounds.size.w;
+    int h = bounds.size.h;
     window_set_background_color(window, GColorBlack);
 
-    int h = bounds.size.h;
-    GRect forecast_frame;
-    GRect weather_status_frame;
-    GRect time_frame;
-    GRect calendar_frame;
-    GRect calendar_status_frame;
-    GRect loading_frame;
 #ifdef PBL_PLATFORM_EMERY
     // emery: pad to avoid content getting obscured by screen edge
     int content_x = EMERY_WINDOW_PAD_X;
     int content_y = EMERY_WINDOW_PAD_TOP;
-    int content_w = bounds.size.w - EMERY_WINDOW_PAD_X * 2;
-    int forecast_w = bounds.size.w - content_x;
+    int content_w = w - EMERY_WINDOW_PAD_X * 2;
+    int forecast_w = w - content_x;
     int content_h = h - EMERY_WINDOW_PAD_TOP - EMERY_WINDOW_PAD_BOTTOM - CALENDAR_STATUS_HEIGHT - WEATHER_STATUS_HEIGHT;
     int calendar_h;
     int time_h;
@@ -65,27 +62,27 @@ static void main_window_load(Window *window) {
     int weather_status_y = time_y + time_h;
     int forecast_y = weather_status_y + WEATHER_STATUS_HEIGHT;
 
-    forecast_frame = GRect(content_x, forecast_y, forecast_w, forecast_h);
-    weather_status_frame = GRect(content_x, weather_status_y, content_w, WEATHER_STATUS_HEIGHT);
-    time_frame = GRect(content_x, time_y, content_w, time_h);
-    calendar_frame = GRect(content_x, calendar_y, content_w, calendar_h);
-    calendar_status_frame = GRect(content_x, content_y, content_w, CALENDAR_STATUS_HEIGHT + 1); // +1 to stop text clipping
-    loading_frame = GRect(content_x, weather_status_y, content_w, h - EMERY_WINDOW_PAD_BOTTOM - weather_status_y);
+    forecast_layer_create(window_layer, GRect(content_x, forecast_y, forecast_w, forecast_h));
+    weather_status_layer_create(window_layer, GRect(content_x, weather_status_y, content_w, WEATHER_STATUS_HEIGHT));
+    time_layer_create(window_layer, GRect(content_x, time_y, content_w, time_h));
+    calendar_layer_create(window_layer, GRect(content_x, calendar_y, content_w, calendar_h));
+    calendar_status_layer_create(window_layer, GRect(content_x, content_y, content_w, CALENDAR_STATUS_HEIGHT + 1)); // +1 to stop text clipping
+    loading_layer_create(window_layer, GRect(content_x, weather_status_y, content_w, h - EMERY_WINDOW_PAD_BOTTOM - weather_status_y));
 #else
-    forecast_frame = GRect(0, h - FORECAST_HEIGHT, bounds.size.w, FORECAST_HEIGHT);
-    weather_status_frame = GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, bounds.size.w, WEATHER_STATUS_HEIGHT);
-    time_frame = GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT - TIME_HEIGHT,
-                       bounds.size.w, TIME_HEIGHT);
-    calendar_frame = GRect(0, CALENDAR_STATUS_HEIGHT, bounds.size.w, CALENDAR_HEIGHT);
-    calendar_status_frame = GRect(0, 0, bounds.size.w, CALENDAR_STATUS_HEIGHT + 1); // +1 to stop text clipping
-    loading_frame = GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, bounds.size.w, FORECAST_HEIGHT + WEATHER_STATUS_HEIGHT);
+    forecast_layer_create(window_layer,
+            GRect(0, h - FORECAST_HEIGHT, w, FORECAST_HEIGHT));
+    weather_status_layer_create(window_layer,
+            GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, w, WEATHER_STATUS_HEIGHT));
+    time_layer_create(window_layer,
+            GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT - TIME_HEIGHT,
+            bounds.size.w, TIME_HEIGHT));
+    calendar_layer_create(window_layer,
+            GRect(0, CALENDAR_STATUS_HEIGHT, bounds.size.w, CALENDAR_HEIGHT));
+    calendar_status_layer_create(window_layer,
+            GRect(0, 0, bounds.size.w, CALENDAR_STATUS_HEIGHT + 1));  // +1 to stop text clipping
+    loading_layer_create(window_layer,
+            GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, w, FORECAST_HEIGHT + WEATHER_STATUS_HEIGHT));
 #endif
-    forecast_layer_create(window_layer, forecast_frame);
-    weather_status_layer_create(window_layer, weather_status_frame);
-    time_layer_create(window_layer, time_frame);
-    calendar_layer_create(window_layer, calendar_frame);
-    calendar_status_layer_create(window_layer, calendar_status_frame);
-    loading_layer_create(window_layer, loading_frame);
     loading_layer_refresh();
     app_message_send_startup_state(loading_layer_has_valid_data());
     MEMORY_LOG_HEAP("after_window_load");

--- a/src/c/windows/main_window.c
+++ b/src/c/windows/main_window.c
@@ -26,8 +26,7 @@
 static Window *s_main_window;
 
 #ifdef PBL_PLATFORM_EMERY
-static void compute_content_layout(int content_h, int *calendar_h, int *time_h, int *forecast_h)
-{
+static void compute_content_layout(int content_h, int *calendar_h, int *time_h, int *forecast_h) {
     const int weight_sum = CALENDAR_HEIGHT + TIME_HEIGHT + FORECAST_HEIGHT;
 
     *calendar_h = (content_h * CALENDAR_HEIGHT) / weight_sum;
@@ -36,8 +35,7 @@ static void compute_content_layout(int content_h, int *calendar_h, int *time_h, 
 }
 #endif
 
-static void main_window_load(Window *window)
-{
+static void main_window_load(Window *window) {
     // Get information about the Window
     Layer *window_layer = window_get_root_layer(window);
     GRect bounds = layer_get_bounds(window_layer);
@@ -93,8 +91,7 @@ static void main_window_load(Window *window)
     MEMORY_LOG_HEAP("after_window_load");
 }
 
-static void main_window_unload(Window *window)
-{
+static void main_window_unload(Window *window) {
     MEMORY_LOG_HEAP("before_window_unload");
     time_layer_destroy();
     weather_status_layer_destroy();
@@ -105,12 +102,10 @@ static void main_window_unload(Window *window)
     MEMORY_LOG_HEAP("after_window_unload");
 }
 
-static void minute_handler(struct tm *tick_time, TimeUnits units_changed)
-{
+static void minute_handler(struct tm *tick_time, TimeUnits units_changed) {
     time_layer_tick();
     /* tm_hour==0 missed day changes from emulator time jumps (same clock, new date). */
-    if (units_changed & DAY_UNIT)
-    {
+    if (units_changed & DAY_UNIT) {
         calendar_layer_refresh();
         calendar_status_layer_refresh();
     }
@@ -122,15 +117,15 @@ static void minute_handler(struct tm *tick_time, TimeUnits units_changed)
 -------- EXTERNAL ------------
 ----------------------------*/
 
-void main_window_create()
-{
+void main_window_create() {
     // Create main Window element and assign to pointer
     s_main_window = window_create();
 
     // Set handlers to manage the elements inside the Window
-    window_set_window_handlers(s_main_window, (WindowHandlers){
-                                                  .load = main_window_load,
-                                                  .unload = main_window_unload});
+    window_set_window_handlers(s_main_window, (WindowHandlers) {
+        .load = main_window_load,
+        .unload = main_window_unload
+    });
 
     // Register with TickTimerService
     tick_timer_service_subscribe(MINUTE_UNIT | DAY_UNIT, minute_handler);
@@ -140,8 +135,7 @@ void main_window_create()
     time_layer_refresh();
 }
 
-void main_window_refresh()
-{
+void main_window_refresh() {
     time_layer_refresh();
     weather_status_layer_refresh();
     forecast_layer_refresh();
@@ -149,8 +143,7 @@ void main_window_refresh()
     calendar_status_layer_refresh();
 }
 
-void main_window_destroy()
-{
+void main_window_destroy() {
     // Interface for destroying the main window (implicitly unloads contents)
     window_destroy(s_main_window);
 }

--- a/src/c/windows/main_window.c
+++ b/src/c/windows/main_window.c
@@ -44,6 +44,12 @@ static void main_window_load(Window *window)
     window_set_background_color(window, GColorBlack);
 
     int h = bounds.size.h;
+    GRect forecast_frame;
+    GRect weather_status_frame;
+    GRect time_frame;
+    GRect calendar_frame;
+    GRect calendar_status_frame;
+    GRect loading_frame;
 #ifdef PBL_PLATFORM_EMERY
     // emery: pad to avoid content getting obscured by screen edge
     int content_x = EMERY_WINDOW_PAD_X;
@@ -61,33 +67,27 @@ static void main_window_load(Window *window)
     int weather_status_y = time_y + time_h;
     int forecast_y = weather_status_y + WEATHER_STATUS_HEIGHT;
 
-    forecast_layer_create(window_layer,
-                          GRect(content_x, forecast_y, forecast_w, forecast_h));
-    weather_status_layer_create(window_layer,
-                                GRect(content_x, weather_status_y, content_w, WEATHER_STATUS_HEIGHT));
-    time_layer_create(window_layer,
-                      GRect(content_x, time_y, content_w, time_h));
-    calendar_layer_create(window_layer,
-                          GRect(content_x, calendar_y, content_w, calendar_h));
-    calendar_status_layer_create(window_layer,
-                                 GRect(content_x, content_y, content_w, CALENDAR_STATUS_HEIGHT + 1)); // +1 to stop text clipping
-    loading_layer_create(window_layer,
-                         GRect(content_x, weather_status_y, content_w, h - EMERY_WINDOW_PAD_BOTTOM - weather_status_y));
+    forecast_frame = GRect(content_x, forecast_y, forecast_w, forecast_h);
+    weather_status_frame = GRect(content_x, weather_status_y, content_w, WEATHER_STATUS_HEIGHT);
+    time_frame = GRect(content_x, time_y, content_w, time_h);
+    calendar_frame = GRect(content_x, calendar_y, content_w, calendar_h);
+    calendar_status_frame = GRect(content_x, content_y, content_w, CALENDAR_STATUS_HEIGHT + 1); // +1 to stop text clipping
+    loading_frame = GRect(content_x, weather_status_y, content_w, h - EMERY_WINDOW_PAD_BOTTOM - weather_status_y);
 #else
-    forecast_layer_create(window_layer,
-                          GRect(0, h - FORECAST_HEIGHT, bounds.size.w, FORECAST_HEIGHT));
-    weather_status_layer_create(window_layer,
-                                GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, bounds.size.w, WEATHER_STATUS_HEIGHT));
-    time_layer_create(window_layer,
-                      GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT - TIME_HEIGHT,
-                            bounds.size.w, TIME_HEIGHT));
-    calendar_layer_create(window_layer,
-                          GRect(0, CALENDAR_STATUS_HEIGHT, bounds.size.w, CALENDAR_HEIGHT));
-    calendar_status_layer_create(window_layer,
-                                 GRect(0, 0, bounds.size.w, CALENDAR_STATUS_HEIGHT + 1)); // +1 to stop text clipping
-    loading_layer_create(window_layer,
-                         GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, bounds.size.w, FORECAST_HEIGHT + WEATHER_STATUS_HEIGHT));
+    forecast_frame = GRect(0, h - FORECAST_HEIGHT, bounds.size.w, FORECAST_HEIGHT);
+    weather_status_frame = GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, bounds.size.w, WEATHER_STATUS_HEIGHT);
+    time_frame = GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT - TIME_HEIGHT,
+                       bounds.size.w, TIME_HEIGHT);
+    calendar_frame = GRect(0, CALENDAR_STATUS_HEIGHT, bounds.size.w, CALENDAR_HEIGHT);
+    calendar_status_frame = GRect(0, 0, bounds.size.w, CALENDAR_STATUS_HEIGHT + 1); // +1 to stop text clipping
+    loading_frame = GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, bounds.size.w, FORECAST_HEIGHT + WEATHER_STATUS_HEIGHT);
 #endif
+    forecast_layer_create(window_layer, forecast_frame);
+    weather_status_layer_create(window_layer, weather_status_frame);
+    time_layer_create(window_layer, time_frame);
+    calendar_layer_create(window_layer, calendar_frame);
+    calendar_status_layer_create(window_layer, calendar_status_frame);
+    loading_layer_create(window_layer, loading_frame);
     loading_layer_refresh();
     app_message_send_startup_state(loading_layer_has_valid_data());
     MEMORY_LOG_HEAP("after_window_load");

--- a/src/c/windows/main_window.c
+++ b/src/c/windows/main_window.c
@@ -16,6 +16,7 @@
 #define EMERY_WINDOW_PAD_X 2
 #define EMERY_WINDOW_PAD_TOP 2
 #define EMERY_WINDOW_PAD_BOTTOM 4
+// emery: increase top calendar status row height to fit larger month and icon alignment.
 #ifdef PBL_PLATFORM_EMERY
 #define CALENDAR_STATUS_HEIGHT 20
 #else
@@ -24,11 +25,7 @@
 
 static Window *s_main_window;
 
-static bool is_emery_display(GRect bounds)
-{
-    return bounds.size.w == 200 && bounds.size.h == 228;
-}
-
+#ifdef PBL_PLATFORM_EMERY
 static void compute_content_layout(int content_h, int *calendar_h, int *time_h, int *forecast_h)
 {
     const int weight_sum = CALENDAR_HEIGHT + TIME_HEIGHT + FORECAST_HEIGHT;
@@ -37,6 +34,7 @@ static void compute_content_layout(int content_h, int *calendar_h, int *time_h, 
     *time_h = (content_h * TIME_HEIGHT) / weight_sum;
     *forecast_h = content_h - *calendar_h - *time_h;
 }
+#endif
 
 static void main_window_load(Window *window)
 {
@@ -45,59 +43,51 @@ static void main_window_load(Window *window)
     GRect bounds = layer_get_bounds(window_layer);
     window_set_background_color(window, GColorBlack);
 
-    if (is_emery_display(bounds))
-    {
-        int h = bounds.size.h;
-        int content_x = EMERY_WINDOW_PAD_X;
-        int content_y = EMERY_WINDOW_PAD_TOP;
-        int content_w = bounds.size.w - EMERY_WINDOW_PAD_X * 2;
-        int forecast_w = bounds.size.w - content_x;
-        int content_h = bounds.size.h - EMERY_WINDOW_PAD_TOP - EMERY_WINDOW_PAD_BOTTOM - CALENDAR_STATUS_HEIGHT - WEATHER_STATUS_HEIGHT;
-        int calendar_h;
-        int time_h;
-        int forecast_h;
-        int calendar_y;
-        int time_y;
-        int weather_status_y;
-        int forecast_y;
+    int h = bounds.size.h;
+#ifdef PBL_PLATFORM_EMERY
+    // emery: pad to avoid content getting obscured by screen edge
+    int content_x = EMERY_WINDOW_PAD_X;
+    int content_y = EMERY_WINDOW_PAD_TOP;
+    int content_w = bounds.size.w - EMERY_WINDOW_PAD_X * 2;
+    int forecast_w = bounds.size.w - content_x;
+    int content_h = h - EMERY_WINDOW_PAD_TOP - EMERY_WINDOW_PAD_BOTTOM - CALENDAR_STATUS_HEIGHT - WEATHER_STATUS_HEIGHT;
+    int calendar_h;
+    int time_h;
+    int forecast_h;
+    compute_content_layout(content_h, &calendar_h, &time_h, &forecast_h);
 
-        compute_content_layout(content_h, &calendar_h, &time_h, &forecast_h);
-        calendar_y = content_y + CALENDAR_STATUS_HEIGHT;
-        time_y = calendar_y + calendar_h;
-        weather_status_y = time_y + time_h;
-        forecast_y = weather_status_y + WEATHER_STATUS_HEIGHT;
+    int calendar_y = content_y + CALENDAR_STATUS_HEIGHT;
+    int time_y = calendar_y + calendar_h;
+    int weather_status_y = time_y + time_h;
+    int forecast_y = weather_status_y + WEATHER_STATUS_HEIGHT;
 
-        forecast_layer_create(window_layer,
-                              GRect(content_x, forecast_y, forecast_w, forecast_h));
-        weather_status_layer_create(window_layer,
-                                    GRect(content_x, weather_status_y, content_w, WEATHER_STATUS_HEIGHT));
-        time_layer_create(window_layer,
-                          GRect(content_x, time_y, content_w, time_h));
-        calendar_layer_create(window_layer,
-                              GRect(content_x, calendar_y, content_w, calendar_h));
-        calendar_status_layer_create(window_layer,
-                                     GRect(content_x, content_y, content_w, CALENDAR_STATUS_HEIGHT + 1)); // +1 to stop text clipping
-        loading_layer_create(window_layer,
-                             GRect(content_x, weather_status_y, content_w, h - EMERY_WINDOW_PAD_BOTTOM - weather_status_y));
-    }
-    else
-    {
-        int h = bounds.size.h;
-
-        forecast_layer_create(window_layer,
-                              GRect(0, h - FORECAST_HEIGHT, bounds.size.w, FORECAST_HEIGHT));
-        weather_status_layer_create(window_layer,
-                                    GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, bounds.size.w, WEATHER_STATUS_HEIGHT));
-        time_layer_create(window_layer,
-                          GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT - TIME_HEIGHT,
-                                bounds.size.w, TIME_HEIGHT));
-        calendar_layer_create(window_layer,
-                              GRect(0, CALENDAR_STATUS_HEIGHT, bounds.size.w, CALENDAR_HEIGHT));
-        calendar_status_layer_create(window_layer,
-                                     GRect(0, 0, bounds.size.w, CALENDAR_STATUS_HEIGHT + 1)); // +1 to stop text clipping
-        loading_layer_create(window_layer,
-                             GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, bounds.size.w, FORECAST_HEIGHT + WEATHER_STATUS_HEIGHT));
-    }
+    forecast_layer_create(window_layer,
+                          GRect(content_x, forecast_y, forecast_w, forecast_h));
+    weather_status_layer_create(window_layer,
+                                GRect(content_x, weather_status_y, content_w, WEATHER_STATUS_HEIGHT));
+    time_layer_create(window_layer,
+                      GRect(content_x, time_y, content_w, time_h));
+    calendar_layer_create(window_layer,
+                          GRect(content_x, calendar_y, content_w, calendar_h));
+    calendar_status_layer_create(window_layer,
+                                 GRect(content_x, content_y, content_w, CALENDAR_STATUS_HEIGHT + 1)); // +1 to stop text clipping
+    loading_layer_create(window_layer,
+                         GRect(content_x, weather_status_y, content_w, h - EMERY_WINDOW_PAD_BOTTOM - weather_status_y));
+#else
+    forecast_layer_create(window_layer,
+                          GRect(0, h - FORECAST_HEIGHT, bounds.size.w, FORECAST_HEIGHT));
+    weather_status_layer_create(window_layer,
+                                GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, bounds.size.w, WEATHER_STATUS_HEIGHT));
+    time_layer_create(window_layer,
+                      GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT - TIME_HEIGHT,
+                            bounds.size.w, TIME_HEIGHT));
+    calendar_layer_create(window_layer,
+                          GRect(0, CALENDAR_STATUS_HEIGHT, bounds.size.w, CALENDAR_HEIGHT));
+    calendar_status_layer_create(window_layer,
+                                 GRect(0, 0, bounds.size.w, CALENDAR_STATUS_HEIGHT + 1)); // +1 to stop text clipping
+    loading_layer_create(window_layer,
+                         GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, bounds.size.w, FORECAST_HEIGHT + WEATHER_STATUS_HEIGHT));
+#endif
     loading_layer_refresh();
     app_message_send_startup_state(loading_layer_has_valid_data());
     MEMORY_LOG_HEAP("after_window_load");

--- a/src/c/windows/main_window.c
+++ b/src/c/windows/main_window.c
@@ -13,37 +13,98 @@
 #define WEATHER_STATUS_HEIGHT 14
 #define TIME_HEIGHT 45
 #define CALENDAR_HEIGHT 45
+#define EMERY_WINDOW_PAD_X 2
+#define EMERY_WINDOW_PAD_TOP 2
+#define EMERY_WINDOW_PAD_BOTTOM 4
+#ifdef PBL_PLATFORM_EMERY
+#define CALENDAR_STATUS_HEIGHT 20
+#else
 #define CALENDAR_STATUS_HEIGHT 13
+#endif
 
 static Window *s_main_window;
 
-static void main_window_load(Window *window) {
+static bool is_emery_display(GRect bounds)
+{
+    return bounds.size.w == 200 && bounds.size.h == 228;
+}
+
+static void compute_content_layout(int content_h, int *calendar_h, int *time_h, int *forecast_h)
+{
+    const int weight_sum = CALENDAR_HEIGHT + TIME_HEIGHT + FORECAST_HEIGHT;
+
+    *calendar_h = (content_h * CALENDAR_HEIGHT) / weight_sum;
+    *time_h = (content_h * TIME_HEIGHT) / weight_sum;
+    *forecast_h = content_h - *calendar_h - *time_h;
+}
+
+static void main_window_load(Window *window)
+{
     // Get information about the Window
     Layer *window_layer = window_get_root_layer(window);
     GRect bounds = layer_get_bounds(window_layer);
-    int w = bounds.size.w;
-    int h = bounds.size.h;
     window_set_background_color(window, GColorBlack);
 
-    forecast_layer_create(window_layer,
-            GRect(0, h - FORECAST_HEIGHT, w, FORECAST_HEIGHT));
-    weather_status_layer_create(window_layer,
-            GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, w, WEATHER_STATUS_HEIGHT));
-    time_layer_create(window_layer,
-            GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT - TIME_HEIGHT,
-            bounds.size.w, TIME_HEIGHT));
-    calendar_layer_create(window_layer,
-            GRect(0, CALENDAR_STATUS_HEIGHT, bounds.size.w, CALENDAR_HEIGHT));
-    calendar_status_layer_create(window_layer,
-            GRect(0, 0, bounds.size.w, CALENDAR_STATUS_HEIGHT + 1));  // +1 to stop text clipping
-    loading_layer_create(window_layer,
-            GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, w, FORECAST_HEIGHT + WEATHER_STATUS_HEIGHT));
+    if (is_emery_display(bounds))
+    {
+        int h = bounds.size.h;
+        int content_x = EMERY_WINDOW_PAD_X;
+        int content_y = EMERY_WINDOW_PAD_TOP;
+        int content_w = bounds.size.w - EMERY_WINDOW_PAD_X * 2;
+        int forecast_w = bounds.size.w - content_x;
+        int content_h = bounds.size.h - EMERY_WINDOW_PAD_TOP - EMERY_WINDOW_PAD_BOTTOM - CALENDAR_STATUS_HEIGHT - WEATHER_STATUS_HEIGHT;
+        int calendar_h;
+        int time_h;
+        int forecast_h;
+        int calendar_y;
+        int time_y;
+        int weather_status_y;
+        int forecast_y;
+
+        compute_content_layout(content_h, &calendar_h, &time_h, &forecast_h);
+        calendar_y = content_y + CALENDAR_STATUS_HEIGHT;
+        time_y = calendar_y + calendar_h;
+        weather_status_y = time_y + time_h;
+        forecast_y = weather_status_y + WEATHER_STATUS_HEIGHT;
+
+        forecast_layer_create(window_layer,
+                              GRect(content_x, forecast_y, forecast_w, forecast_h));
+        weather_status_layer_create(window_layer,
+                                    GRect(content_x, weather_status_y, content_w, WEATHER_STATUS_HEIGHT));
+        time_layer_create(window_layer,
+                          GRect(content_x, time_y, content_w, time_h));
+        calendar_layer_create(window_layer,
+                              GRect(content_x, calendar_y, content_w, calendar_h));
+        calendar_status_layer_create(window_layer,
+                                     GRect(content_x, content_y, content_w, CALENDAR_STATUS_HEIGHT + 1)); // +1 to stop text clipping
+        loading_layer_create(window_layer,
+                             GRect(content_x, weather_status_y, content_w, h - EMERY_WINDOW_PAD_BOTTOM - weather_status_y));
+    }
+    else
+    {
+        int h = bounds.size.h;
+
+        forecast_layer_create(window_layer,
+                              GRect(0, h - FORECAST_HEIGHT, bounds.size.w, FORECAST_HEIGHT));
+        weather_status_layer_create(window_layer,
+                                    GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, bounds.size.w, WEATHER_STATUS_HEIGHT));
+        time_layer_create(window_layer,
+                          GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT - TIME_HEIGHT,
+                                bounds.size.w, TIME_HEIGHT));
+        calendar_layer_create(window_layer,
+                              GRect(0, CALENDAR_STATUS_HEIGHT, bounds.size.w, CALENDAR_HEIGHT));
+        calendar_status_layer_create(window_layer,
+                                     GRect(0, 0, bounds.size.w, CALENDAR_STATUS_HEIGHT + 1)); // +1 to stop text clipping
+        loading_layer_create(window_layer,
+                             GRect(0, h - FORECAST_HEIGHT - WEATHER_STATUS_HEIGHT, bounds.size.w, FORECAST_HEIGHT + WEATHER_STATUS_HEIGHT));
+    }
     loading_layer_refresh();
     app_message_send_startup_state(loading_layer_has_valid_data());
     MEMORY_LOG_HEAP("after_window_load");
 }
 
-static void main_window_unload(Window *window) {
+static void main_window_unload(Window *window)
+{
     MEMORY_LOG_HEAP("before_window_unload");
     time_layer_destroy();
     weather_status_layer_destroy();
@@ -54,10 +115,12 @@ static void main_window_unload(Window *window) {
     MEMORY_LOG_HEAP("after_window_unload");
 }
 
-static void minute_handler(struct tm *tick_time, TimeUnits units_changed) {
+static void minute_handler(struct tm *tick_time, TimeUnits units_changed)
+{
     time_layer_tick();
     /* tm_hour==0 missed day changes from emulator time jumps (same clock, new date). */
-    if (units_changed & DAY_UNIT) {
+    if (units_changed & DAY_UNIT)
+    {
         calendar_layer_refresh();
         calendar_status_layer_refresh();
     }
@@ -69,15 +132,15 @@ static void minute_handler(struct tm *tick_time, TimeUnits units_changed) {
 -------- EXTERNAL ------------
 ----------------------------*/
 
-void main_window_create() {
+void main_window_create()
+{
     // Create main Window element and assign to pointer
     s_main_window = window_create();
 
     // Set handlers to manage the elements inside the Window
-    window_set_window_handlers(s_main_window, (WindowHandlers) {
-        .load = main_window_load,
-        .unload = main_window_unload
-    });
+    window_set_window_handlers(s_main_window, (WindowHandlers){
+                                                  .load = main_window_load,
+                                                  .unload = main_window_unload});
 
     // Register with TickTimerService
     tick_timer_service_subscribe(MINUTE_UNIT | DAY_UNIT, minute_handler);
@@ -87,7 +150,8 @@ void main_window_create() {
     time_layer_refresh();
 }
 
-void main_window_refresh() {
+void main_window_refresh()
+{
     time_layer_refresh();
     weather_status_layer_refresh();
     forecast_layer_refresh();
@@ -95,7 +159,8 @@ void main_window_refresh() {
     calendar_status_layer_refresh();
 }
 
-void main_window_destroy() {
+void main_window_destroy()
+{
     // Interface for destroying the main window (implicitly unloads contents)
     window_destroy(s_main_window);
 }


### PR DESCRIPTION
Increases font sizes and tweaks layout for the larger screen.

Note the built-in fonts are a mixed bag regarding which sizes they support, so not every font option scales up an equal amount.

A few tweaks were made to the forecast X-axis — I moved the numbers down below the tick marks since we have the vertical real estate, and I added more frequent tick marks since we have more horizontal space. Time is now labeled with a number every 3 hours (compared to every 4 hours on other platforms), and every hour is marked (compared to every 2 hours on other platforms).

The only thing I didn't change the size of is the bitmap assets, that may come in a follow-up PR.

<img width="200" height="228" alt="pebble_screenshot_2026-05-15_00-57-30" src="https://github.com/user-attachments/assets/1d19a889-c3ec-4c2c-a740-a00396fdf073" />


Closes #134 