### PR TITLE
feat: migrate default weekend and holiday colors to red (folly)

### DIFF
--- a/src/c/appendix/config.c
+++ b/src/c/appendix/config.c
@@ -24,9 +24,9 @@ static Config config_defaults(void) {
         .show_am_pm = false,
         .time_font = TIME_FONT_ROBOTO,
         .color_today = GColorBlack,
-        .color_saturday = GColorWhite,
-        .color_sunday = GColorWhite,
-        .color_us_federal = GColorWhite,
+        .color_saturday = GColorFolly,
+        .color_sunday = GColorFolly,
+        .color_us_federal = GColorFolly,
         .color_time = GColorWhite,
         .day_night_shading = true
     };

--- a/src/c/appendix/persist.c
+++ b/src/c/appendix/persist.c
@@ -54,9 +54,9 @@ void persist_init() {
             .show_bt_disconnect = true,
             .vibe = false,
             .show_am_pm = false,
-            .color_saturday = GColorWhite,	
-            .color_sunday = GColorWhite,
-            .color_us_federal = GColorWhite,
+            .color_saturday = GColorFolly,
+            .color_sunday = GColorFolly,
+            .color_us_federal = GColorFolly,
             .color_time = GColorWhite,
             .day_night_shading = true
         };

--- a/src/pkjs/clay/config.js
+++ b/src/pkjs/clay/config.js
@@ -126,7 +126,7 @@ module.exports = [
                 "type": "color",
                 "label": "Sunday color",
                 "messageKey": "colorSunday",
-                "defaultValue": "#FFFFFF",
+                "defaultValue": "#FF0055",
                 "sunlight": false,
                 "capabilities": ["COLOR"]
             },
@@ -134,7 +134,7 @@ module.exports = [
                 "type": "color",
                 "label": "Saturday color",
                 "messageKey": "colorSaturday",
-                "defaultValue": "#FFFFFF",
+                "defaultValue": "#FF0055",
                 "sunlight": false,
                 "capabilities": ["COLOR"]
             },
@@ -142,8 +142,8 @@ module.exports = [
                 "type": "color",
                 "label": "US federal holidays color",
                 "messageKey": "colorUSFederal",
-                "defaultValue": "#FFFFFF",
-                "description": "White (default) means disable",
+                "defaultValue": "#FF0055",
+                "description": "White means disable",
                 "sunlight": false,
                 "capabilities": ["COLOR"]
             },

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -45,6 +45,9 @@ var KEY_LAST_FETCH_SUCCESS = storageKeys.LAST_FETCH_SUCCESS_KEY;
 var KEY_LAST_FETCH_ATTEMPT = storageKeys.LAST_FETCH_ATTEMPT_KEY;
 var KEY_GEOCODE_CACHE = storageKeys.GEOCODE_CACHE_KEY;
 var KEY_GEOCODE_BACKOFF = storageKeys.GEOCODE_BACKOFF_KEY;
+var KEY_V1_34_0_WEEKEND_HOLIDAY_COLOR_MIGRATION = 'v1.34.0_weekend_holiday_color_migration';
+var DEFAULT_COLOR_WHITE = pebbleColors.GColorWhite;
+var DEFAULT_COLOR_FOLLY = pebbleColors.GColorFolly;
 
 app.fetchInProgress = false;
 app.pendingStartupFetch = false;
@@ -111,6 +114,7 @@ Pebble.addEventListener('ready',
             app.devConfig.forceShowReleaseNotificationOnBoot
         );
         clayTryDefaults();
+        clayTryWeekendHolidayColorMigration();
         clayTryDevConfig(app.devConfig);
         clayTryFixtureSettings(activeFixture);
         console.log('PebbleKit JS ready!');
@@ -376,7 +380,7 @@ function sendClaySettings(onSuccess, onFailure) {
         "CLAY_CELSIUS": app.settings.temperatureUnits === 'c',
         "CLAY_TIME_LEAD_ZERO": app.settings.timeLeadingZero,
         "CLAY_AXIS_12H": app.settings.axisTimeFormat === '12h',
-        "CLAY_COLOR_TODAY": app.settings.hasOwnProperty('colorToday') ? app.settings.colorToday : 16777215,
+        "CLAY_COLOR_TODAY": app.settings.hasOwnProperty('colorToday') ? app.settings.colorToday : DEFAULT_COLOR_WHITE,
         "CLAY_START_MON": app.settings.weekStartDay === 'mon',
         "CLAY_PREV_WEEK": app.settings.firstWeek === 'prev',
         "CLAY_TIME_FONT": ['roboto', 'leco', 'bitham'].indexOf(app.settings.timeFont),
@@ -385,10 +389,10 @@ function sendClaySettings(onSuccess, onFailure) {
         "CLAY_SHOW_BT_DISCONNECT": app.settings.btIcons === "disconnected" || app.settings.btIcons === "both",
         "CLAY_VIBE": app.settings.vibe,
         "CLAY_SHOW_AM_PM": app.settings.timeShowAmPm,
-        "CLAY_COLOR_SUNDAY": app.settings.hasOwnProperty('colorSunday') ? app.settings.colorSunday : 16777215,
-        "CLAY_COLOR_SATURDAY": app.settings.hasOwnProperty('colorSaturday') ? app.settings.colorSaturday : 16777215,
-        "CLAY_COLOR_US_FEDERAL": app.settings.hasOwnProperty('colorUSFederal') ? app.settings.colorUSFederal : 16777215,
-        "CLAY_COLOR_TIME": app.settings.hasOwnProperty('colorTime') ? app.settings.colorTime : 16777215,
+        "CLAY_COLOR_SUNDAY": app.settings.hasOwnProperty('colorSunday') ? app.settings.colorSunday : DEFAULT_COLOR_FOLLY,
+        "CLAY_COLOR_SATURDAY": app.settings.hasOwnProperty('colorSaturday') ? app.settings.colorSaturday : DEFAULT_COLOR_FOLLY,
+        "CLAY_COLOR_US_FEDERAL": app.settings.hasOwnProperty('colorUSFederal') ? app.settings.colorUSFederal : DEFAULT_COLOR_FOLLY,
+        "CLAY_COLOR_TIME": app.settings.hasOwnProperty('colorTime') ? app.settings.colorTime : DEFAULT_COLOR_WHITE,
         "CLAY_DAY_NIGHT_SHADING": app.settings.hasOwnProperty('dayNightShading') ? app.settings.dayNightShading : true,
     }
     Pebble.sendAppMessage(payload, function() {
@@ -484,18 +488,58 @@ function getDefaultClaySettings() {
         timeShowAmPm: false,
         axisTimeFormat: '24h',
         timeFont: 'roboto',
-        colorTime: 16777215,
+        colorTime: DEFAULT_COLOR_WHITE,
         weekStartDay: 'sun',
         firstWeek: 'prev',
         colorToday: 0,
-        colorSunday: 16777215,
-        colorSaturday: 16777215,
-        colorUSFederal: 16777215,
+        colorSunday: DEFAULT_COLOR_FOLLY,
+        colorSaturday: DEFAULT_COLOR_FOLLY,
+        colorUSFederal: DEFAULT_COLOR_FOLLY,
         showQt: true,
         vibe: false,
         btIcons: 'both',
         telemetryEnabled: true
     };
+}
+
+/**
+ * Move existing installs from the old all-white weekend/holiday defaults to the
+ * current highlighted default while preserving any customized color set.
+ *
+ * @returns {void}
+ */
+function clayTryWeekendHolidayColorMigration() {
+    var persistClayString = localStorage.getItem('clay-settings');
+    var persistClay;
+
+    if (
+        persistClayString === null ||
+        localStorage.getItem(KEY_V1_34_0_WEEKEND_HOLIDAY_COLOR_MIGRATION) !== null
+    ) {
+        return;
+    }
+
+    try {
+        persistClay = JSON.parse(persistClayString);
+    }
+    catch (ex) {
+        console.log('Malformed clay settings found, skipping weekend/holiday color migration');
+        return;
+    }
+
+    if (
+        persistClay.colorSunday === DEFAULT_COLOR_WHITE &&
+        persistClay.colorSaturday === DEFAULT_COLOR_WHITE &&
+        persistClay.colorUSFederal === DEFAULT_COLOR_WHITE
+    ) {
+        persistClay.colorSunday = DEFAULT_COLOR_FOLLY;
+        persistClay.colorSaturday = DEFAULT_COLOR_FOLLY;
+        persistClay.colorUSFederal = DEFAULT_COLOR_FOLLY;
+        localStorage.setItem('clay-settings', JSON.stringify(persistClay));
+        console.log('Migrated weekend/holiday color defaults to Folly');
+    }
+
+    localStorage.setItem(KEY_V1_34_0_WEEKEND_HOLIDAY_COLOR_MIGRATION, '1');
 }
 
 function getDevConfig() {

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -106,6 +106,8 @@ Pebble.addEventListener('webviewclosed', function(e) {
 // Listen for when the watchface is opened
 Pebble.addEventListener('ready',
     function (e) {
+        var migratedWeekendHolidayColors;
+
         app.devConfig = getDevConfig();
         maybeHandleDevStorageReset(app.devConfig);
         var hadExistingInstall = localStorage.getItem('clay-settings') !== null;
@@ -114,7 +116,7 @@ Pebble.addEventListener('ready',
             app.devConfig.forceShowReleaseNotificationOnBoot
         );
         clayTryDefaults();
-        clayTryWeekendHolidayColorMigration();
+        migratedWeekendHolidayColors = clayTryWeekendHolidayColorMigration();
         clayTryDevConfig(app.devConfig);
         clayTryFixtureSettings(activeFixture);
         console.log('PebbleKit JS ready!');
@@ -135,6 +137,9 @@ Pebble.addEventListener('ready',
                 sendFixtureWeather(activeFixture);
             });
             return;
+        }
+        if (migratedWeekendHolidayColors) {
+            sendClaySettings(markWeekendHolidayColorMigrationComplete);
         }
         if (app.pendingStartupFetch) {
             app.pendingStartupFetch = false;
@@ -326,10 +331,19 @@ function maybeShowReleaseNotification(hadExistingInstall, forceVersionSpec) {
  */
 function maybeHandleDevStorageReset(devConfig) {
     var shouldClear = !!(devConfig && devConfig.clearPkjsStorageOnBoot);
+    var shouldResetV134WeekendHolidayColorMigration = !!(
+        devConfig &&
+        devConfig.resetV134WeekendHolidayColorMigration
+    );
 
     if (shouldClear) {
         console.log('[dev] clearPkjsStorageOnBoot=true, clearing localStorage');
         localStorage.clear();
+    }
+
+    if (shouldResetV134WeekendHolidayColorMigration) {
+        console.log('[dev] resetV134WeekendHolidayColorMigration=true, clearing migration marker');
+        localStorage.removeItem(KEY_V1_34_0_WEEKEND_HOLIDAY_COLOR_MIGRATION);
     }
 }
 
@@ -506,7 +520,7 @@ function getDefaultClaySettings() {
  * Move existing installs from the old all-white weekend/holiday defaults to the
  * current highlighted default while preserving any customized color set.
  *
- * @returns {void}
+ * @returns {boolean} True when the migrated settings should be sent to the watch.
  */
 function clayTryWeekendHolidayColorMigration() {
     var persistClayString = localStorage.getItem('clay-settings');
@@ -516,7 +530,7 @@ function clayTryWeekendHolidayColorMigration() {
         persistClayString === null ||
         localStorage.getItem(KEY_V1_34_0_WEEKEND_HOLIDAY_COLOR_MIGRATION) !== null
     ) {
-        return;
+        return false;
     }
 
     try {
@@ -524,7 +538,7 @@ function clayTryWeekendHolidayColorMigration() {
     }
     catch (ex) {
         console.log('Malformed clay settings found, skipping weekend/holiday color migration');
-        return;
+        return false;
     }
 
     if (
@@ -537,8 +551,27 @@ function clayTryWeekendHolidayColorMigration() {
         persistClay.colorUSFederal = DEFAULT_COLOR_FOLLY;
         localStorage.setItem('clay-settings', JSON.stringify(persistClay));
         console.log('Migrated weekend/holiday color defaults to Folly');
+        return true;
     }
 
+    if (
+        persistClay.colorSunday === DEFAULT_COLOR_FOLLY &&
+        persistClay.colorSaturday === DEFAULT_COLOR_FOLLY &&
+        persistClay.colorUSFederal === DEFAULT_COLOR_FOLLY
+    ) {
+        return true;
+    }
+
+    markWeekendHolidayColorMigrationComplete();
+    return false;
+}
+
+/**
+ * Mark the v1.34.0 weekend/holiday color migration as complete.
+ *
+ * @returns {void}
+ */
+function markWeekendHolidayColorMigrationComplete() {
     localStorage.setItem(KEY_V1_34_0_WEEKEND_HOLIDAY_COLOR_MIGRATION, '1');
 }
 
@@ -562,6 +595,7 @@ function clayTryDevConfig(devConfig) {
     var localOnlyDevConfigKeys = {
         clearPkjsStorageOnBoot: true,
         forceShowReleaseNotificationOnBoot: true,
+        resetV134WeekendHolidayColorMigration: true,
     };
 
     persistClay = getClaySettings();


### PR DESCRIPTION
Changes default sat/sun/holiday colors to `GColorFolly`, a red color that's slightly lightened for readability. This is the loadout I daily drive on the watch face and I think it's a better default because otherwise there's no indication of the weekend/holiday tracking feature.

For users who were on the old default (sat/sun/holidays all set to white color), perform one time migration to the new default.

Tested with a `dev-config.js` flag which resets the migration completion key:
```js
module.exports.resetV134WeekendHolidayColorMigration = true
```

Resolves #143 