### PR TITLE
perf: reduce aplite heap usage by avoiding software math

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ If you need runtime logs, `mise install-emulator --logs` runs it in an emulator 
 - Lazy-load bitmaps and destroy them when they are not needed to keep startup and steady-state heap usage low.
 - Prefer drawing directly in an update proc over creating extra layer objects when a simple render path is enough.
 - If a UI element only exists to paint pixels, keep it as light as possible instead of modeling it as a full layer.
+- Avoid floating-point math and 64-bit division in watch-side C, prefer integer multiply-before-divide so linked software math helper code doesn't consume heap. See #163.
 
 ## Code Conventions
 

--- a/src/c/appendix/math.c
+++ b/src/c/appendix/math.c
@@ -17,13 +17,10 @@ void min_max(int16_t *array, int n, int *min, int *max) {
     }
 }
 
-int roundFloat(float num) 
-{ 
-    return num < 0 ? num - 0.5 : num + 0.5; 
-} 
-  
-
 int f_to_c(int temp_f) {
-    // Convert a fahrenheit temperature to celcius
-    return roundFloat((temp_f - 32) * 5.0 / 9);
+    // Convert a fahrenheit temperature to celsius, rounded to nearest.
+    // Integer arithmetic (no float) keeps the soft-float library out of the
+    // binary; +4/-4 reproduces round-half away from zero over /9.
+    const int num = (temp_f - 32) * 5;
+    return num >= 0 ? (num + 4) / 9 : (num - 4) / 9;
 }

--- a/src/c/layers/battery_layer.c
+++ b/src/c/layers/battery_layer.c
@@ -80,7 +80,7 @@ static void battery_update_proc(Layer *layer, GContext *ctx) {
         battery_w - (BATTERY_STROKE + FILL_PADDING) * 2, h - (BATTERY_STROKE + FILL_PADDING) * 2);
     GRect color_area = GRect(
         color_bounds.origin.x, color_bounds.origin.y,
-        color_bounds.size.w * (float) (battery_level + 10) / (100.0 + 10), color_bounds.size.h);
+        color_bounds.size.w * (battery_level + 10) / 110, color_bounds.size.h);
 #ifdef PBL_COLOR
     graphics_context_set_fill_color(ctx, get_battery_color(battery_level));
 #else

--- a/src/c/layers/calendar_layer.c
+++ b/src/c/layers/calendar_layer.c
@@ -22,9 +22,10 @@
 static Layer *s_calendar_layer;
 
 static GRect calendar_cell_rect(GRect bounds, int i) {
-    float box_w = (float) bounds.size.w / DAYS_PER_WEEK;
-    float box_h = (float) bounds.size.h / NUM_WEEKS;
-    return GRect((i % DAYS_PER_WEEK) * box_w, (i / DAYS_PER_WEEK) * box_h,
+    const int box_w = bounds.size.w / DAYS_PER_WEEK;
+    const int box_h = bounds.size.h / NUM_WEEKS;
+    return GRect((i % DAYS_PER_WEEK) * bounds.size.w / DAYS_PER_WEEK,
+                 (i / DAYS_PER_WEEK) * bounds.size.h / NUM_WEEKS,
                  box_w, box_h);
 }
 
@@ -145,15 +146,15 @@ static void calendar_update_proc(Layer *layer, GContext *ctx) {
     GRect bounds = layer_get_bounds(layer);
     int w = bounds.size.w;
     int h = bounds.size.h;
-    float box_w = (float) w / DAYS_PER_WEEK;
-    float box_h = (float) h / NUM_WEEKS;
+    const int box_w = w / DAYS_PER_WEEK;
+    const int box_h = h / NUM_WEEKS;
 
     // Calculate which box holds today's date
     const int i_today = config_n_today();
 
     graphics_context_set_fill_color(ctx, today_color());
     graphics_fill_rect(ctx,
-        GRect((i_today % DAYS_PER_WEEK) * box_w, (i_today / DAYS_PER_WEEK) * box_h,
+        GRect((i_today % DAYS_PER_WEEK) * w / DAYS_PER_WEEK, (i_today / DAYS_PER_WEEK) * h / NUM_WEEKS,
         box_w, box_h), 1, GCornersAll);
 
     for (int i = 0; i < NUM_WEEKS * DAYS_PER_WEEK; ++i) {

--- a/src/c/layers/forecast_layer.c
+++ b/src/c/layers/forecast_layer.c
@@ -497,8 +497,11 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
     const int temp_plot_h = h - MARGIN_TEMP_H * 2 - BOTTOM_AXIS_H;
     const int range_safe = range > 0 ? range : 1;
 
-    // Draw a bounding box for each data entry (the -1 is since we don't want a gap on either side)
-    float entry_w = (float)graph_bounds.size.w / (num_entries - 1);
+    // Draw a bounding box for each data entry (the -1 is since we don't want a gap on either side).
+    // Pixels per entry is the exact rational graph_w/span; entry positions use integer
+    // multiply-before-divide so the soft-float library stays out of the binary.
+    const int graph_w = graph_bounds.size.w;
+    const int span = num_entries - 1;
     if (render_spec.draw_night_overlay)
     {
         night_segments = compute_night_segments(forecast_start, forecast_end);
@@ -510,14 +513,14 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
     graphics_context_set_stroke_color(ctx, GColorLightGray);
 
     // Round this division up by adding (divisor - 1) to the dividend.
-    const int entries_per_label = ((float)HOUR_LABEL_MIN_SPACING + (entry_w - 1)) / entry_w;
+    const int entries_per_label = ((HOUR_LABEL_MIN_SPACING - 1) * span + graph_w) / graph_w;
     for (int i = 0; i < num_entries; ++i)
     {
-        int entry_x = graph_bounds.origin.x + i * entry_w;
+        int entry_x = graph_bounds.origin.x + i * graph_w / span;
 
         // Save a point for the precipitation probability
         int precip = precips[i];
-        int precip_h = (float)precip / 100.0 * (h - BOTTOM_AXIS_H);
+        int precip_h = precip * (h - BOTTOM_AXIS_H) / 100;
         s_points_precip[i] = GPoint(entry_x, h - BOTTOM_AXIS_H - precip_h);
 
         // Save a point for the temperature reading
@@ -545,7 +548,7 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
 #ifndef PBL_PLATFORM_EMERY
     for (int label_i = 0; label_i < num_entries; label_i += entries_per_label)
     {
-        const int label_x = graph_bounds.origin.x + (int)(label_i * entry_w);
+        const int label_x = graph_bounds.origin.x + label_i * graph_w / span;
         char buf[4];
 
         snprintf(buf, sizeof(buf), "%d", config_axis_hour(forecast_start_local->tm_hour + label_i));
@@ -562,7 +565,7 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
         const int midpoint_i = label_i + entries_per_label / 2;
         if (midpoint_i > label_i && midpoint_i < next_label_i && midpoint_i < num_entries)
         {
-            const int tick_x = graph_bounds.origin.x + (int)(midpoint_i * entry_w);
+            const int tick_x = graph_bounds.origin.x + midpoint_i * graph_w / span;
             graphics_draw_line(ctx,
                                GPoint(tick_x, h - BOTTOM_AXIS_H - 0),
                                GPoint(tick_x, h - BOTTOM_AXIS_H + 4));
@@ -572,7 +575,7 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
 #else
     for (int label_i = 0; label_i < num_entries; label_i += entries_per_label)
     {
-        const int label_x = graph_bounds.origin.x + (int)(label_i * entry_w);
+        const int label_x = graph_bounds.origin.x + label_i * graph_w / span;
         char buf[4];
 
         snprintf(buf, sizeof(buf), "%d", config_axis_hour(forecast_start_local->tm_hour + label_i));

--- a/src/c/layers/forecast_layer.c
+++ b/src/c/layers/forecast_layer.c
@@ -208,8 +208,12 @@ static int16_t graph_x_for_time(time_t timestamp, time_t graph_start, time_t gra
         return graph_right;
     }
 
-    const int64_t elapsed = (int64_t)timestamp - graph_start;
-    const int64_t total = (int64_t)graph_end - graph_start;
+    // The forecast window is bounded (<= (MAX_FORECAST_ENTRIES-1) * FORECAST_STEP_SECONDS,
+    // ~82800s) and elapsed <= total, so elapsed * size.w stays well within int32. Narrowing
+    // from int64 here drops __udivmoddi4/__divdi3 from the binary; the int32 divide is a
+    // single hardware instruction on the Cortex-M3.
+    const int32_t elapsed = (int32_t)(timestamp - graph_start);
+    const int32_t total = (int32_t)(graph_end - graph_start);
     return graph_left + (int16_t)((elapsed * graph_plot_rect.size.w) / total);
 }
 


### PR DESCRIPTION
# Shrink the aplite binary by removing soft-float and 64-bit division

## Summary

A handful of geometry/temperature calculations use floating point, and one
time-to-pixel mapping uses 64-bit integer division. Pebble's MCU has no FPU and
no wide integer divide, so each links a `libgcc` helper into the **app binary**.
On aplite the binary, statics, heap, and stack share one **24 KB** RAM region,
so those routines come straight out of the app heap.

Converting the float math to integers and narrowing the one (bounded) 64-bit
division to 32-bit drops both runtimes. Measured, this nearly doubles aplite's
free heap, with **no change to rendered output**:

| Platform | Footprint before → after | Free heap before → after |
|---|---|---|
| **aplite (24 KB)** | 17,472 → 12,536 B | **7,104 → 12,040 B (+4,936)** |
| basalt (64 KB) | 17,904 → 12,992 B | 47,632 → 52,544 B |
| diorite (64 KB) | 17,720 → 13,744 B | 47,816 → 51,792 B |
| emery (128 KB) | 18,196 → 13,280 B | 112,876 → 117,792 B |
| flint (64 KB) | 17,720 → 12,784 B | 47,816 → 52,752 B |

Every platform shrinks ~4–5 KB; aplite is where it matters, since it has the
least headroom for the layers, fonts, and AppMessage inbox the watchface
allocates at startup — the same memory pressure the
`wip/aplite-memory-investigation` / `feat/reduce-aplite-memory-pressure`
branches were chasing. Two commits: float removal, then the 64-bit division.

## What links the runtimes

- **Double (~2.7 KB):** four bare-`double` literals promote whole expressions to
  double — `math.c` `roundFloat`/`f_to_c`, `forecast_layer.c` precip height,
  `battery_layer.c` fill width — pulling
  `__adddf3`/`__subdf3`/`__muldf3`/`__divdf3` + conversions.
- **Single (~1.7 KB):** `calendar_layer.c` cell geometry and `forecast_layer.c`
  `entry_w` spacing pull `__addsf3`/`__subsf3`/`__mulsf3`/`__divsf3`/`__frsub`.
- **64-bit divide (~0.75 KB):** `graph_x_for_time` maps time→x in `int64`,
  pulling `__udivmoddi4`/`__divdi3`.

## The fix

**Commit 1 — float → integer.** `f_to_c` uses integer round-half
(`(num ± 4) / 9`, dropping `roundFloat`); calendar cells, forecast
entry/label/tick positions, precip-bar height, and battery-fill width use
integer multiply-before-divide; the label-spacing step becomes the exact integer
form of the old float ceil,
`((HOUR_LABEL_MIN_SPACING - 1) * span + graph_w) / graph_w`. No float remains, so
the whole soft-float runtime unlinks.

**Commit 2 — 64-bit → 32-bit divide.** `graph_x_for_time` narrows
`elapsed`/`total` to `int32`. The window is bounded by
`(MAX_FORECAST_ENTRIES - 1) * FORECAST_STEP_SECONDS` (~82,800 s) with
`elapsed <= total`, so `elapsed * size.w` (≤ ~16.5 M) is well within `int32`;
the subtraction stays in `time_t` before narrowing, so timestamp magnitude is
irrelevant. The `int32` divide is a single hardware `SDIV` on the Cortex-M3.

## Correctness

Output is **pixel-equivalent**, not approximate:

- Multiply-before-divide (`k * W / n`) yields the same truncated pixel the old
  `(int)(k * (float)W / n)` did, without float rounding error.
- The label-spacing formula is the algebraic integer identity of the old float
  expression (verified on representative widths/entry counts).
- `f_to_c`'s `±4` reproduces `roundFloat`'s round-half over `/9` exactly.
- `forecast_update` early-returns when `num_entries < 2`, so the `/span` divide
  cannot divide by zero (the float code relied on the same guard).

basalt/diorite/emery/flint render byte-identically (re-captured screenshots
unchanged). Source-only — no resource, layout, API, or settings changes.


If you are also interested in to add the rain precipation now let me now.
I settled on something like this
<img width="170" height="199" alt="image" src="https://github.com/user-attachments/assets/bab2a0af-6f59-4f14-bda0-350b78e1b80a" />

