### PR TITLE
Add light appearance and enhanced status displays

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,6 +266,7 @@ Fixtures currently support:
 - `watchSettings.timeFormat`: watch-level time display preference, `"12h"` or `"24h"`.
 - `claySettings`: Clay-compatible settings keyed by `messageKey`, such as `"axisTimeFormat": "12h"`. Color settings use Pebble SDK color constants like `"GColorFolly"` from the Rebble color definitions: https://developer.rebble.io/docs/c/Graphics/Graphics_Types/Color_Definitions/
 - `weather.city`: weather status city label.
+- `weather.condition`: current weather condition displayed in the weather status row.
 - `weather.currentTemp`: current temperature in Fahrenheit.
 - `weather.startHour`: local hour for the first forecast entry; fixture prep converts it to the runtime forecast timestamp.
 - `weather.temps`: hourly Fahrenheit forecast values.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Open source revival of the beloved ForecasWatch watchface. This includes support
 ## Features
 
 * Current time
-* Battery indicator
+* Battery indicator (with numeric percentage on Pebble Time 2)
 * 3 week calendar
 * 24 hour weather forecast (updates every 30 minutes)
 * Bluetooth connection indicator
@@ -32,11 +32,12 @@ Open source revival of the beloved ForecasWatch watchface. This includes support
 * Current temperature
 * Temperature forecast (red line)
 * Precipitation probability forecast (blue area)
-* City where forecast was fetched
+* Current weather condition or forecast location
 * Next sunrise or sunset time
 * GPS or manual location entry
 * Fahrenheit and Celsius temperatures
 * Customize time font and color
+* Light and dark appearance
 * Customize colors for Sundays, Saturdays, and US federal holidays
 * Offline configuration page
 

--- a/fixtures/light.json
+++ b/fixtures/light.json
@@ -9,14 +9,14 @@
       "second": 0
     },
     "battery": {
-      "percent": 100
+      "percent": 82
     }
   },
   "watchSettings": {
     "timeFormat": "12h"
   },
   "claySettings": {
-    "appearance": "dark",
+    "appearance": "light",
     "weatherStatusText": "condition",
     "axisTimeFormat": "12h",
     "colorSaturday": "GColorFolly",

--- a/package.template.json
+++ b/package.template.json
@@ -70,6 +70,7 @@
       "NUM_ENTRIES",
       "CURRENT_TEMP",
       "CITY",
+      "CONDITION",
       "SUN_EVENTS",
       "WATCH_HAS_FORECAST_DATA",
       "CLAY_CELSIUS",
@@ -88,7 +89,9 @@
       "CLAY_COLOR_SUNDAY",
       "CLAY_COLOR_US_FEDERAL",
       "CLAY_COLOR_TIME",
-      "CLAY_DAY_NIGHT_SHADING"
+      "CLAY_DAY_NIGHT_SHADING",
+      "CLAY_LIGHT_MODE",
+      "CLAY_WEATHER_STATUS_CONDITION"
     ]
   }
 }

--- a/src/c/appendix/app_message.c
+++ b/src/c/appendix/app_message.c
@@ -18,6 +18,7 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
     Tuple *num_entries_tuple = dict_find(iterator, MESSAGE_KEY_NUM_ENTRIES);
     Tuple *current_temp_tuple = dict_find(iterator, MESSAGE_KEY_CURRENT_TEMP);
     Tuple *city_tuple = dict_find(iterator, MESSAGE_KEY_CITY);
+    Tuple *condition_tuple = dict_find(iterator, MESSAGE_KEY_CONDITION);
     Tuple *sun_events_tuple = dict_find(iterator, MESSAGE_KEY_SUN_EVENTS);
 
     // Clay config options
@@ -38,8 +39,11 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
     Tuple *clay_color_us_federal_tuple = dict_find(iterator, MESSAGE_KEY_CLAY_COLOR_US_FEDERAL);
     Tuple *clay_color_time_tuple = dict_find(iterator, MESSAGE_KEY_CLAY_COLOR_TIME);
     Tuple *clay_day_night_shading_tuple = dict_find(iterator, MESSAGE_KEY_CLAY_DAY_NIGHT_SHADING);
+    Tuple *clay_light_mode_tuple = dict_find(iterator, MESSAGE_KEY_CLAY_LIGHT_MODE);
+    Tuple *clay_weather_status_condition_tuple = dict_find(iterator, MESSAGE_KEY_CLAY_WEATHER_STATUS_CONDITION);
 
-    if(temp_trend_tuple && temp_trend_tuple && forecast_start_tuple && num_entries_tuple && city_tuple && sun_events_tuple) {
+    if(temp_trend_tuple && precip_trend_tuple && forecast_start_tuple && num_entries_tuple && current_temp_tuple
+        && city_tuple && condition_tuple && sun_events_tuple) {
         // Weather data received
         APP_LOG(APP_LOG_LEVEL_INFO, "All tuples received!");
         persist_set_forecast_start((time_t)forecast_start_tuple->value->int32);
@@ -56,6 +60,7 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
         uint8_t *precip_data = (uint8_t*) precip_trend_tuple->value->data;
         persist_set_precip_trend(precip_data, num_entries);
         persist_set_city((char*)city_tuple->value->cstring);
+        persist_set_condition((char*)condition_tuple->value->cstring);
         int lo, hi;
         min_max(temp_data, num_entries, &lo, &hi);
         persist_set_temp_lo(lo);
@@ -74,7 +79,8 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
     else if (clay_celsius_tuple && clay_time_lead_zero_tuple && clay_axis_12h_tuple && clay_start_mon_tuple && clay_prev_week_tuple
         && clay_color_today_tuple && clay_time_font_tuple && clay_vibe_tuple && clay_show_qt_tuple && clay_show_bt_tuple
         && clay_show_bt_disconnect_tuple && clay_show_am_pm_tuple && clay_color_saturday_tuple && clay_color_sunday_tuple
-        && clay_color_us_federal_tuple && clay_color_time_tuple && clay_day_night_shading_tuple) {
+        && clay_color_us_federal_tuple && clay_color_time_tuple && clay_day_night_shading_tuple && clay_light_mode_tuple
+        && clay_weather_status_condition_tuple) {
         // Clay config data received
         bool clay_celsius = (bool) (clay_celsius_tuple->value->int16);
         bool time_lead_zero = (bool) (clay_time_lead_zero_tuple->value->int16);
@@ -87,6 +93,8 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
         bool show_bt_disconnect = (bool) (clay_show_bt_disconnect_tuple->value->int16);
         bool show_am_pm = (bool) (clay_show_am_pm_tuple->value->int16);
         bool day_night_shading = (bool) (clay_day_night_shading_tuple->value->int16);
+        bool light_mode = (bool) (clay_light_mode_tuple->value->int16);
+        bool weather_status_condition = (bool) (clay_weather_status_condition_tuple->value->int16);
         int16_t time_font = clay_time_font_tuple->value->int16;
         GColor color_today = GColorFromHEX(clay_color_today_tuple->value->int32);
         GColor color_saturday = GColorFromHEX(clay_color_saturday_tuple->value->int32);
@@ -110,7 +118,9 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
             .color_sunday = color_sunday,
             .color_us_federal = color_us_federal,
             .color_time = color_time,
-            .day_night_shading = day_night_shading
+            .day_night_shading = day_night_shading,
+            .light_mode = light_mode,
+            .weather_status_condition = weather_status_condition
         };
         persist_set_config(config);
         main_window_refresh();

--- a/src/c/appendix/config.c
+++ b/src/c/appendix/config.c
@@ -28,7 +28,9 @@ static Config config_defaults(void) {
         .color_sunday = GColorFolly,
         .color_us_federal = GColorFolly,
         .color_time = GColorWhite,
-        .day_night_shading = true
+        .day_night_shading = true,
+        .light_mode = false,
+        .weather_status_condition = true
     };
 }
 
@@ -113,6 +115,34 @@ GFont config_time_font() {
     if (font_index < 0 || font_index >= font_count)
         font_index = TIME_FONT_ROBOTO;
     return fonts_get_system_font(font_keys[font_index]);
+}
+
+GColor config_background_color() {
+    return g_config->light_mode ? GColorWhite : GColorBlack;
+}
+
+GColor config_foreground_color() {
+    return g_config->light_mode ? GColorBlack : GColorWhite;
+}
+
+GColor config_secondary_color() {
+    return PBL_IF_COLOR_ELSE(g_config->light_mode ? GColorDarkGray : GColorLightGray,
+                             config_foreground_color());
+}
+
+GColor config_muted_color() {
+    return PBL_IF_COLOR_ELSE(g_config->light_mode ? GColorLightGray : GColorDarkGray,
+                             config_foreground_color());
+}
+
+GColor config_time_color() {
+#ifdef PBL_COLOR
+    return gcolor_equal(g_config->color_time, config_background_color())
+        ? config_foreground_color()
+        : g_config->color_time;
+#else
+    return config_foreground_color();
+#endif
 }
 
 bool config_highlight_holidays() {

--- a/src/c/appendix/config.h
+++ b/src/c/appendix/config.h
@@ -26,6 +26,8 @@ typedef struct {
     GColor color_us_federal;
     GColor color_time;
     bool day_night_shading;
+    bool light_mode;
+    bool weather_status_condition;
 } Config;
 
 extern Config *g_config;
@@ -45,6 +47,16 @@ int config_axis_hour(int hour);
 int config_n_today();
 
 GFont config_time_font();
+
+GColor config_background_color();
+
+GColor config_foreground_color();
+
+GColor config_secondary_color();
+
+GColor config_muted_color();
+
+GColor config_time_color();
 
 bool config_highlight_holidays();
 

--- a/src/c/appendix/persist.c
+++ b/src/c/appendix/persist.c
@@ -3,7 +3,7 @@
 
 enum key {
     TEMP_LO, TEMP_HI, TEMP_TREND, PRECIP_TREND, FORECAST_START, CITY, SUN_EVENT_START_TYPE, SUN_EVENT_TIMES, NUM_ENTRIES,
-    CURRENT_TEMP, BATTERY_LEVEL, CONFIG
+    CURRENT_TEMP, BATTERY_LEVEL, CONFIG, CONDITION
 }; // Deprecated: BATTERY_LEVEL
 
 void persist_init() {
@@ -33,6 +33,9 @@ void persist_init() {
     if (!persist_exists(CITY)) {
         persist_write_string(CITY, "Koji");
     }
+    if (!persist_exists(CONDITION)) {
+        persist_write_string(CONDITION, "Unknown");
+    }
     if (!persist_exists(SUN_EVENT_START_TYPE)) {
         persist_write_int(SUN_EVENT_START_TYPE, 0);
     }
@@ -58,7 +61,9 @@ void persist_init() {
             .color_sunday = GColorFolly,
             .color_us_federal = GColorFolly,
             .color_time = GColorWhite,
-            .day_night_shading = true
+            .day_night_shading = true,
+            .light_mode = false,
+            .weather_status_condition = true
         };
         persist_set_config(config);
     }
@@ -94,6 +99,10 @@ int persist_get_current_temp() {
 
 int persist_get_city(char *buffer, const size_t buffer_size) {
     return persist_read_string(CITY, buffer, buffer_size);
+}
+
+int persist_get_condition(char *buffer, const size_t buffer_size) {
+    return persist_read_string(CONDITION, buffer, buffer_size);
 }
 
 int persist_get_sun_event_start_type() {
@@ -138,6 +147,10 @@ void persist_set_current_temp(int val) {
 
 void persist_set_city(char *val) {
     persist_write_string(CITY, val);
+}
+
+void persist_set_condition(char *val) {
+    persist_write_string(CONDITION, val);
 }
 
 void persist_set_sun_event_start_type(int val) {

--- a/src/c/appendix/persist.h
+++ b/src/c/appendix/persist.h
@@ -22,6 +22,8 @@ int persist_get_current_temp();
 
 int persist_get_city(char *buffer, const size_t buffer_size);
 
+int persist_get_condition(char *buffer, const size_t buffer_size);
+
 int persist_get_sun_event_start_type();
 
 int persist_get_sun_event_times(time_t *buffer, const size_t buffer_size);
@@ -43,6 +45,8 @@ void persist_set_num_entries(int val);
 void persist_set_current_temp(int val);
 
 void persist_set_city(char *val);
+
+void persist_set_condition(char *val);
 
 void persist_set_sun_event_start_type(int val);
 

--- a/src/c/layers/battery_layer.c
+++ b/src/c/layers/battery_layer.c
@@ -1,20 +1,23 @@
 #include "battery_layer.h"
-#include "c/appendix/persist.h"
+#include "c/appendix/config.h"
 #include "c/appendix/memory_log.h"
 #include "c/services/watch_services.h"
 
+#define BATTERY_BODY_W 11
+#define BATTERY_BODY_H 10
 #define BATTERY_NUB_W 2
-#define BATTERY_NUB_H 6
+#define BATTERY_NUB_H 4
 #define BATTERY_STROKE 1
 #define FILL_PADDING 1
-#define ICON_SPACING 3
-#define BATTERY_POWER_ICON_W 7
+#define TEXT_ICON_SPACING 2
+#define BATTERY_TEXT_OFFSET 5
 
 
 static Layer *s_battery_layer;
 static GBitmap *s_battery_power_bitmap;
 static GColor s_battery_palette[2];
 static bool s_battery_subscribed;
+static bool s_battery_palette_initialized;
 
 static void battery_state_handler(BatteryChargeState charge) {
     battery_layer_refresh();
@@ -31,12 +34,17 @@ static GColor get_battery_color(int level) {
 }
 #endif
 
-static void ensure_battery_power_bitmap_loaded(void) {
+static void ensure_battery_power_bitmap_loaded(GColor fill_color) {
+    GColor icon_color = gcolor_legible_over(fill_color);
     if (!s_battery_power_bitmap) {
         s_battery_power_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_BATTERY_CHARGING);
-        s_battery_palette[0] = GColorWhite;
+        s_battery_palette_initialized = false;
+    }
+    if (!s_battery_palette_initialized || !gcolor_equal(s_battery_palette[0], icon_color)) {
+        s_battery_palette[0] = icon_color;
         s_battery_palette[1] = GColorClear;
         gbitmap_set_palette(s_battery_power_bitmap, s_battery_palette, false);
+        s_battery_palette_initialized = true;
     }
 }
 
@@ -44,13 +52,14 @@ static void maybe_unload_battery_power_bitmap(bool show_power_icon) {
     if (!show_power_icon && s_battery_power_bitmap) {
         gbitmap_destroy(s_battery_power_bitmap);
         s_battery_power_bitmap = NULL;
+        s_battery_palette_initialized = false;
     }
 }
 
-static void draw_power_icon(GContext *ctx, int h, GBitmap *icon_bitmap) {
+static void draw_power_icon(GContext *ctx, int body_x, int body_y, GBitmap *icon_bitmap) {
     GRect icon_bounds = gbitmap_get_bounds(icon_bitmap);
-    int icon_x = 0;
-    int icon_y = (h - icon_bounds.size.h) / 2;
+    int icon_x = body_x + (BATTERY_BODY_W - icon_bounds.size.w) / 2;
+    int icon_y = body_y + (BATTERY_BODY_H - icon_bounds.size.h) / 2;
 
     graphics_context_set_compositing_mode(ctx, GCompOpSet);
     graphics_draw_bitmap_in_rect(
@@ -61,47 +70,64 @@ static void draw_power_icon(GContext *ctx, int h, GBitmap *icon_bitmap) {
 }
 
 static void battery_update_proc(Layer *layer, GContext *ctx) {
+    MEMORY_LOG_HEAP("battery_update:enter");
     GRect bounds = layer_get_bounds(layer);
     int w = bounds.size.w;
     int h = bounds.size.h;
     BatteryChargeState battery_state = watch_services_battery_state();
     int battery_level = battery_state.charge_percent;
     bool show_power_icon = battery_state.is_charging || battery_state.is_plugged;
+    GColor fill_color = PBL_IF_COLOR_ELSE(get_battery_color(battery_level), config_foreground_color());
 
     maybe_unload_battery_power_bitmap(show_power_icon);
 
-    int battery_x = BATTERY_POWER_ICON_W + ICON_SPACING;
-    int battery_total_w = w - battery_x;
-    int battery_w = battery_total_w - BATTERY_NUB_W;
+    const int battery_x = w - BATTERY_BODY_W - BATTERY_NUB_W;
+    const int battery_y = (h - BATTERY_BODY_H) / 2;
+    const int fill_max_w = BATTERY_BODY_W - (BATTERY_STROKE + FILL_PADDING) * 2;
+    int fill_w = fill_max_w * battery_level / 100;
+    if (battery_level > 0 && fill_w == 0) {
+        fill_w = 1;
+    }
+
+#ifdef PBL_PLATFORM_EMERY
+    // emery: the larger status row has room for a percentage beside the icon.
+    char battery_text[5];
+    snprintf(battery_text, sizeof(battery_text), "%d%%", battery_level);
+    graphics_context_set_text_color(ctx, config_foreground_color());
+    graphics_draw_text(ctx, battery_text,
+                       fonts_get_system_font(FONT_KEY_GOTHIC_14),
+                       GRect(0, battery_y - BATTERY_TEXT_OFFSET,
+                             battery_x - TEXT_ICON_SPACING,
+                             h - battery_y + BATTERY_TEXT_OFFSET),
+                       GTextOverflowModeFill, GTextAlignmentRight, NULL);
+#endif
 
     // Fill the battery level
     GRect color_bounds = GRect(
-        battery_x + BATTERY_STROKE + FILL_PADDING, BATTERY_STROKE + FILL_PADDING,
-        battery_w - (BATTERY_STROKE + FILL_PADDING) * 2, h - (BATTERY_STROKE + FILL_PADDING) * 2);
+        battery_x + BATTERY_STROKE + FILL_PADDING, battery_y + BATTERY_STROKE + FILL_PADDING,
+        fill_max_w, BATTERY_BODY_H - (BATTERY_STROKE + FILL_PADDING) * 2);
     GRect color_area = GRect(
         color_bounds.origin.x, color_bounds.origin.y,
-        color_bounds.size.w * (battery_level + 10) / 110, color_bounds.size.h);
-#ifdef PBL_COLOR
-    graphics_context_set_fill_color(ctx, get_battery_color(battery_level));
-#else
-    graphics_context_set_fill_color(ctx, GColorWhite);
-#endif
+        fill_w, color_bounds.size.h);
+    graphics_context_set_fill_color(ctx, fill_color);
     graphics_fill_rect(ctx, color_area, 0, GCornerNone);
 
     if (show_power_icon) {
-        ensure_battery_power_bitmap_loaded();
-        draw_power_icon(ctx, h, s_battery_power_bitmap);
+        ensure_battery_power_bitmap_loaded(fill_color);
+        draw_power_icon(ctx, battery_x, battery_y, s_battery_power_bitmap);
     }
 
-    // Draw the white battery outline
-    graphics_context_set_stroke_color(ctx, GColorWhite);
+    // Draw the battery outline
+    graphics_context_set_stroke_color(ctx, config_foreground_color());
     graphics_context_set_stroke_width(ctx, BATTERY_STROKE);
-    graphics_draw_rect(ctx, GRect(battery_x, 0, battery_w, h));
+    graphics_draw_rect(ctx, GRect(battery_x, battery_y, BATTERY_BODY_W, BATTERY_BODY_H));
 
     // Draw the battery nub on the right
     graphics_draw_rect(
-        ctx,
-        GRect(battery_x + battery_w - 1, h / 2 - BATTERY_NUB_H / 2, BATTERY_NUB_W + 1, BATTERY_NUB_H));
+        ctx, GRect(battery_x + BATTERY_BODY_W - 1,
+              battery_y + BATTERY_BODY_H / 2 - BATTERY_NUB_H / 2,
+              BATTERY_NUB_W + 1, BATTERY_NUB_H));
+    MEMORY_LOG_HEAP("battery_update:exit");
 }
 
 void battery_layer_create(Layer* parent_layer, GRect frame) {
@@ -125,7 +151,9 @@ void battery_layer_create(Layer* parent_layer, GRect frame) {
 }
 
 void battery_layer_refresh() {
-    layer_mark_dirty(s_battery_layer);
+    if (s_battery_layer) {
+        layer_mark_dirty(s_battery_layer);
+    }
 }
 
 void battery_layer_destroy() {
@@ -137,6 +165,7 @@ void battery_layer_destroy() {
     if (s_battery_power_bitmap) {
         gbitmap_destroy(s_battery_power_bitmap);
         s_battery_power_bitmap = NULL;
+        s_battery_palette_initialized = false;
     }
     layer_destroy(s_battery_layer);
     MEMORY_LOG_HEAP("battery_layer_destroy:after");

--- a/src/c/layers/calendar_layer.c
+++ b/src/c/layers/calendar_layer.c
@@ -122,13 +122,13 @@ static bool is_us_federal_holiday(struct tm *t)
 #ifdef PBL_COLOR
 static GColor date_color(struct tm *t) {
     // Get color for a date, considering weekends and holidays
-    if (is_us_federal_holiday(t))
+    if (is_us_federal_holiday(t) && config_highlight_holidays())
         return g_config->color_us_federal;
-    if (t->tm_wday == 0)
+    if (t->tm_wday == 0 && config_highlight_sundays())
         return g_config->color_sunday;
-    if (t->tm_wday == 6)
+    if (t->tm_wday == 6 && config_highlight_saturdays())
         return g_config->color_saturday;
-    return GColorWhite;
+    return config_foreground_color();
 }
 #endif
 
@@ -138,7 +138,7 @@ static GColor today_color() {
     struct tm t = relative_tm(0);
     return gcolor_equal(g_config->color_today, GColorBlack) ? date_color(&t) : g_config->color_today;
 #else
-    return GColorWhite;
+    return config_foreground_color();
 #endif
 }
 
@@ -164,7 +164,7 @@ static void calendar_update_proc(Layer *layer, GContext *ctx) {
         bool highlight_saturday = (config_highlight_saturdays() && t.tm_wday == 6);
         bool bold = (i == i_today) || highlight_holiday || highlight_sunday || highlight_saturday;
         GColor text_color = (i == i_today) ? gcolor_legible_over(today_color())
-                                           : PBL_IF_COLOR_ELSE(date_color(&t), GColorWhite);
+                                           : PBL_IF_COLOR_ELSE(date_color(&t), config_foreground_color());
         char buffer[4];
         GFont font = fonts_get_system_font(bold ? CALENDAR_FONT_KEY_BOLD : CALENDAR_FONT_KEY);
         GRect cell_rect = calendar_cell_rect(bounds, i);

--- a/src/c/layers/calendar_status_layer.c
+++ b/src/c/layers/calendar_status_layer.c
@@ -11,7 +11,7 @@
 // emery: center icons in the taller status row.
 #ifdef PBL_PLATFORM_EMERY
 // emery: reserve extra width for the numeric battery percentage.
-#define BATTERY_W 42
+#define BATTERY_W 46
 #define STATUS_ICON_Y(bounds_h, icon_h) (((bounds_h) - (icon_h)) / 2)
 #define MONTH_FONT_KEY FONT_KEY_GOTHIC_24
 #else

--- a/src/c/layers/calendar_status_layer.c
+++ b/src/c/layers/calendar_status_layer.c
@@ -4,20 +4,19 @@
 #include "c/appendix/memory_log.h"
 #include "c/services/watch_services.h"
 
-#define BATTERY_W 29
-#define BATTERY_H 10
 #define PADDING 4
 #define MONTH_FONT_OFFSET 7
 #define ICON_SLOT_1 GRect(PADDING, 0, 10, 10)
 #define ICON_SLOT_2 GRect(PADDING * 2 + 10, 0, 10, 10)
 // emery: center icons in the taller status row.
 #ifdef PBL_PLATFORM_EMERY
+// emery: reserve extra width for the numeric battery percentage.
+#define BATTERY_W 42
 #define STATUS_ICON_Y(bounds_h, icon_h) (((bounds_h) - (icon_h)) / 2)
-#define BATTERY_Y(bounds_h) (((bounds_h) - BATTERY_H) / 2)
 #define MONTH_FONT_KEY FONT_KEY_GOTHIC_24
 #else
+#define BATTERY_W 29
 #define STATUS_ICON_Y(bounds_h, icon_h) ((void)(bounds_h), (void)(icon_h), 0)
-#define BATTERY_Y(bounds_h) ((void)(bounds_h), 1)
 #define MONTH_FONT_KEY FONT_KEY_GOTHIC_18
 #endif
 
@@ -29,6 +28,9 @@ static GBitmap *s_bt_disconnect_bitmap;
 static GColor s_bt_palette[2];
 static GColor s_bt_disconnect_palette[2];
 static GColor s_mute_palette[2];
+static bool s_bt_palette_initialized;
+static bool s_bt_disconnect_palette_initialized;
+static bool s_mute_palette_initialized;
 
 static GRect month_text_rect(GRect bounds, GFont font) {
 #ifdef PBL_PLATFORM_EMERY
@@ -46,7 +48,7 @@ static GRect month_text_rect(GRect bounds, GFont font) {
 
 static void draw_month_text(GContext *ctx, GRect bounds) {
     const GFont month_font = fonts_get_system_font(MONTH_FONT_KEY);
-    graphics_context_set_text_color(ctx, GColorWhite);
+    graphics_context_set_text_color(ctx, config_foreground_color());
     graphics_draw_text(
         ctx,
         s_calendar_month_text,
@@ -64,29 +66,44 @@ static void draw_bitmap(GContext *ctx, GBitmap *bitmap, GRect frame) {
 }
 
 static void ensure_mute_bitmap_loaded(void) {
+    GColor icon_color = config_foreground_color();
     if (!s_mute_bitmap) {
         s_mute_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_MUTE);
-        s_mute_palette[0] = GColorWhite;
+        s_mute_palette_initialized = false;
+    }
+    if (!s_mute_palette_initialized || !gcolor_equal(s_mute_palette[0], icon_color)) {
+        s_mute_palette[0] = icon_color;
         s_mute_palette[1] = GColorClear;
         gbitmap_set_palette(s_mute_bitmap, s_mute_palette, false);
+        s_mute_palette_initialized = true;
     }
 }
 
 static void ensure_bt_bitmap_loaded(void) {
+    GColor icon_color = PBL_IF_COLOR_ELSE(GColorPictonBlue, config_foreground_color());
     if (!s_bt_bitmap) {
         s_bt_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_BT_CONNECT);
-        s_bt_palette[0] = PBL_IF_COLOR_ELSE(GColorPictonBlue, GColorWhite);
+        s_bt_palette_initialized = false;
+    }
+    if (!s_bt_palette_initialized || !gcolor_equal(s_bt_palette[0], icon_color)) {
+        s_bt_palette[0] = icon_color;
         s_bt_palette[1] = GColorClear;
         gbitmap_set_palette(s_bt_bitmap, s_bt_palette, false);
+        s_bt_palette_initialized = true;
     }
 }
 
 static void ensure_bt_disconnect_bitmap_loaded(void) {
+    GColor icon_color = PBL_IF_COLOR_ELSE(GColorRed, config_foreground_color());
     if (!s_bt_disconnect_bitmap) {
         s_bt_disconnect_bitmap = gbitmap_create_with_resource(RESOURCE_ID_IMAGE_BT_DISCONNECT);
-        s_bt_disconnect_palette[0] = PBL_IF_COLOR_ELSE(GColorRed, GColorWhite);
+        s_bt_disconnect_palette_initialized = false;
+    }
+    if (!s_bt_disconnect_palette_initialized || !gcolor_equal(s_bt_disconnect_palette[0], icon_color)) {
+        s_bt_disconnect_palette[0] = icon_color;
         s_bt_disconnect_palette[1] = GColorClear;
         gbitmap_set_palette(s_bt_disconnect_bitmap, s_bt_disconnect_palette, false);
+        s_bt_disconnect_palette_initialized = true;
     }
 }
 
@@ -97,20 +114,24 @@ static void maybe_unload_calendar_status_bitmaps(bool show_qt, bool connected) {
     if (!show_qt && s_mute_bitmap) {
         gbitmap_destroy(s_mute_bitmap);
         s_mute_bitmap = NULL;
+        s_mute_palette_initialized = false;
     }
 
     if (!show_bt && s_bt_bitmap) {
         gbitmap_destroy(s_bt_bitmap);
         s_bt_bitmap = NULL;
+        s_bt_palette_initialized = false;
     }
 
     if (!show_bt_disconnect && s_bt_disconnect_bitmap) {
         gbitmap_destroy(s_bt_disconnect_bitmap);
         s_bt_disconnect_bitmap = NULL;
+        s_bt_disconnect_palette_initialized = false;
     }
 }
 
 static void calendar_status_update_proc(Layer *layer, GContext *ctx) {
+    MEMORY_LOG_HEAP("calendar_status_update:enter");
     GRect bounds = layer_get_bounds(layer);
     bool show_qt = show_qt_icon();
     bool connected = connection_service_peek_pebble_app_connection();
@@ -135,6 +156,7 @@ static void calendar_status_update_proc(Layer *layer, GContext *ctx) {
     }
 
     draw_month_text(ctx, bounds);
+    MEMORY_LOG_HEAP("calendar_status_update:exit");
 }
 
 void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
@@ -158,7 +180,7 @@ void calendar_status_layer_create(Layer* parent_layer, GRect frame) {
     MEMORY_HEAP_PROBE_SAMPLE("after_update_proc_set", &probe);
 
     battery_layer_create(s_calendar_status_layer,
-                         GRect(w - BATTERY_W - PADDING, BATTERY_Y(bounds.size.h), BATTERY_W, BATTERY_H));
+                         GRect(w - BATTERY_W - PADDING, 0, BATTERY_W, bounds.size.h));
     MEMORY_HEAP_PROBE_SAMPLE("after_battery_layer_create", &probe);
 
     layer_add_child(parent_layer, s_calendar_status_layer);
@@ -194,6 +216,7 @@ void calendar_status_layer_refresh() {
     struct tm tm_now = watch_services_localtime();
     strftime(s_calendar_month_text, sizeof(s_calendar_month_text), "%b %Y", &tm_now);
     status_icons_refresh();
+    battery_layer_refresh();
 }
 
 void calendar_status_layer_destroy() {
@@ -202,14 +225,17 @@ void calendar_status_layer_destroy() {
     if (s_mute_bitmap) {
         gbitmap_destroy(s_mute_bitmap);
         s_mute_bitmap = NULL;
+        s_mute_palette_initialized = false;
     }
     if (s_bt_bitmap) {
         gbitmap_destroy(s_bt_bitmap);
         s_bt_bitmap = NULL;
+        s_bt_palette_initialized = false;
     }
     if (s_bt_disconnect_bitmap) {
         gbitmap_destroy(s_bt_disconnect_bitmap);
         s_bt_disconnect_bitmap = NULL;
+        s_bt_disconnect_palette_initialized = false;
     }
     layer_destroy(s_calendar_status_layer);
     MEMORY_LOG_HEAP("calendar_status_layer_destroy:after");

--- a/src/c/layers/forecast_layer.c
+++ b/src/c/layers/forecast_layer.c
@@ -25,12 +25,9 @@
 #define FORECAST_BOTTOM_PAD 0
 #endif
 #define NIGHT_HATCH_SPACING PBL_IF_COLOR_ELSE(6, 7)
-#define NIGHT_HATCH_COLOR GColorDarkGray
 #define PRECIP_FILL_COLOR PBL_IF_COLOR_ELSE(GColorCobaltBlue, GColorLightGray)
 #define NIGHT_PRECIP_FILL_COLOR PBL_IF_COLOR_ELSE(GColorDukeBlue, GColorLightGray)
 #define NIGHT_HATCH_COLOR_PRECIP PBL_IF_COLOR_ELSE(GColorBlue, GColorWhite)
-#define NIGHT_BOUNDARY_COLOR PBL_IF_COLOR_ELSE(GColorDarkGray, GColorLightGray)
-#define NIGHT_BOUNDARY_COLOR_PRECIP PBL_IF_COLOR_ELSE(GColorVividCerulean, GColorWhite)
 #define FORECAST_STEP_SECONDS (60 * 60)
 #define DAY_SECONDS (24 * 60 * 60)
 #define MAX_FORECAST_ENTRIES 24
@@ -82,11 +79,12 @@ static RenderSpec make_render_spec()
 {
     RenderSpec spec = {
         .draw_night_overlay = g_config->day_night_shading,
-        .axis_color = PBL_IF_COLOR_ELSE(GColorOrange, GColorWhite)};
+        .axis_color = PBL_IF_COLOR_ELSE(g_config->light_mode ? GColorRed : GColorOrange,
+                                        config_foreground_color())};
 
     if (spec.draw_night_overlay)
     {
-        spec.axis_color = PBL_IF_COLOR_ELSE(GColorRed, GColorWhite);
+        spec.axis_color = PBL_IF_COLOR_ELSE(GColorRed, config_foreground_color());
     }
 
     return spec;
@@ -265,7 +263,7 @@ static void draw_night_regions(GContext *ctx, GRect graph_plot_rect, time_t grap
 
     const int16_t hatch_spacing = NIGHT_HATCH_SPACING;
     const bool is_color = PBL_IF_COLOR_ELSE(true, false);
-    graphics_context_set_stroke_color(ctx, is_color ? NIGHT_HATCH_COLOR : GColorWhite);
+    graphics_context_set_stroke_color(ctx, is_color ? config_muted_color() : config_foreground_color());
 
     for (int i = 0; i < night_segments->count; ++i)
     {
@@ -380,7 +378,7 @@ static void draw_night_hatch_over_precip(GContext *ctx, GRect graph_plot_rect, t
             }
         }
 
-        graphics_context_set_stroke_color(ctx, is_color ? NIGHT_HATCH_COLOR_PRECIP : GColorWhite);
+        graphics_context_set_stroke_color(ctx, is_color ? NIGHT_HATCH_COLOR_PRECIP : config_foreground_color());
         for (int16_t x = x0; x < x1; ++x)
         {
             const int16_t precip_y = clamped_precip_top_y_for_x(graph_plot_rect, points_precip, num_entries, x);
@@ -401,7 +399,7 @@ static void draw_night_boundaries(GContext *ctx, GRect graph_plot_rect, time_t g
         return;
     }
 
-    graphics_context_set_stroke_color(ctx, NIGHT_BOUNDARY_COLOR);
+    graphics_context_set_stroke_color(ctx, config_muted_color());
     graphics_context_set_stroke_width(ctx, 1);
 
     const int16_t y0 = graph_plot_rect.origin.y;
@@ -434,7 +432,8 @@ static void draw_night_boundaries_over_precip(GContext *ctx, GRect graph_plot_re
         return;
     }
 
-    graphics_context_set_stroke_color(ctx, NIGHT_BOUNDARY_COLOR_PRECIP);
+    graphics_context_set_stroke_color(ctx,
+        PBL_IF_COLOR_ELSE(GColorVividCerulean, config_foreground_color()));
     graphics_context_set_stroke_width(ctx, 1);
 
     const int16_t y_bottom = graph_plot_rect.origin.y + graph_plot_rect.size.h - 1;
@@ -478,7 +477,7 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
     MemoryHeapProbe redraw_probe = MEMORY_HEAP_PROBE_START("forecast_update");
     if (num_entries < 2)
     {
-        graphics_context_set_fill_color(ctx, GColorBlack);
+        graphics_context_set_fill_color(ctx, config_background_color());
         graphics_fill_rect(ctx, bounds, 0, GCornerNone);
         MEMORY_LOG_HEAP("forecast_update:exit");
         return;
@@ -513,8 +512,8 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
         draw_night_boundaries(ctx, graph_plot_rect, forecast_start, forecast_end, &night_segments);
     }
 
-    graphics_context_set_text_color(ctx, GColorWhite);
-    graphics_context_set_stroke_color(ctx, GColorLightGray);
+    graphics_context_set_text_color(ctx, config_foreground_color());
+    graphics_context_set_stroke_color(ctx, config_secondary_color());
 
     // Round this division up by adding (divisor - 1) to the dividend.
     const int entries_per_label = ((HOUR_LABEL_MIN_SPACING - 1) * span + graph_w) / graph_w;
@@ -539,7 +538,7 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
         // emery: draw emphasized major/minor bottom-axis ticks for improved readability.
 #ifdef PBL_PLATFORM_EMERY
         const bool is_label_tick = (i % entries_per_label) == 0;
-        const GColor tick_color = is_label_tick ? GColorLightGray : GColorDarkGray;
+        const GColor tick_color = is_label_tick ? config_secondary_color() : config_muted_color();
         graphics_context_set_stroke_width(ctx, 1);
         graphics_context_set_stroke_color(ctx, tick_color);
         graphics_draw_line(ctx,
@@ -627,7 +626,7 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
     s_path_temp.num_points = num_entries;
     s_path_temp.points = s_points_temp;
     MEMORY_HEAP_PROBE_SAMPLE("before_temp_path_draw", &redraw_probe);
-    graphics_context_set_stroke_color(ctx, PBL_IF_COLOR_ELSE(GColorRed, GColorWhite));
+    graphics_context_set_stroke_color(ctx, PBL_IF_COLOR_ELSE(GColorRed, config_foreground_color()));
     graphics_context_set_stroke_width(ctx, 3); // Only odd stroke width values supported
     gpath_draw_outline_open(ctx, &s_path_temp);
     MEMORY_HEAP_PROBE_SAMPLE("after_temp_path_draw", &redraw_probe);
@@ -638,10 +637,10 @@ static void forecast_update_proc(Layer *layer, GContext *ctx)
     const int16_t axis_y = h - BOTTOM_AXIS_H;
     graphics_draw_line(ctx, GPoint(graph_bounds.origin.x, axis_y), GPoint(graph_bounds.origin.x + w, axis_y));
     // And for the left side axis
-    graphics_context_set_fill_color(ctx, GColorBlack);
+    graphics_context_set_fill_color(ctx, config_background_color());
     graphics_fill_rect(ctx, GRect(0, 0, s_axis_left_w, h - BOTTOM_AXIS_H), 0, GCornerNone); // Paint over plot bleeding
     graphics_draw_line(ctx, GPoint(graph_bounds.origin.x, 0), GPoint(graph_bounds.origin.x, axis_y));
-    graphics_context_set_text_color(ctx, GColorWhite);
+    graphics_context_set_text_color(ctx, config_foreground_color());
     GSize hi_size = temp_label_string_size(s_buffer_hi);
     GSize lo_size = temp_label_string_size(s_buffer_lo);
     // emery: anchor hi/lo labels to the top/bottom of the axis strip to avoid clipping.

--- a/src/c/layers/loading_layer.c
+++ b/src/c/layers/loading_layer.c
@@ -1,5 +1,6 @@
 #include "loading_layer.h"
 #include "c/appendix/persist.h"
+#include "c/appendix/config.h"
 #include "c/appendix/memory_log.h"
 #include "c/services/watch_services.h"
 
@@ -18,8 +19,8 @@ static void loading_update_proc(Layer *layer, GContext *ctx) {
     int w = bounds.size.w;
     int h = bounds.size.h;
 
-    // Black out the weather components
-    graphics_context_set_fill_color(ctx, GColorBlack);
+    // Cover the weather components with the current appearance background.
+    graphics_context_set_fill_color(ctx, config_background_color());
     graphics_fill_rect(ctx, GRect(0, 0, w, h), 0, GCornerNone);
 }
 
@@ -30,7 +31,7 @@ void loading_layer_create(Layer* parent_layer, GRect frame) {
     int w = bounds.size.w; int h = bounds.size.h;
     s_loading_text_layer = text_layer_create(GRect(0, h / 3, w, h));
     text_layer_set_background_color(s_loading_text_layer, GColorClear);
-    text_layer_set_text_color(s_loading_text_layer, GColorWhite);
+    text_layer_set_text_color(s_loading_text_layer, config_foreground_color());
     text_layer_set_font(s_loading_text_layer, fonts_get_system_font(FONT_KEY_GOTHIC_18));
     text_layer_set_text_alignment(s_loading_text_layer, GTextAlignmentCenter);
     text_layer_set_text(s_loading_text_layer, "No data :(");
@@ -42,6 +43,8 @@ void loading_layer_create(Layer* parent_layer, GRect frame) {
 }
 
 void loading_layer_refresh() {
+    text_layer_set_text_color(s_loading_text_layer, config_foreground_color());
+    layer_mark_dirty(s_loading_layer);
     if (loading_layer_has_valid_data())
         layer_set_hidden(s_loading_layer, true);
     else

--- a/src/c/layers/time_layer.c
+++ b/src/c/layers/time_layer.c
@@ -29,7 +29,7 @@ void time_layer_create(Layer* parent_layer, GRect frame) {
     // AM/PM formatting
     text_layer_set_font(s_am_pm_layer, fonts_get_system_font(FONT_KEY_GOTHIC_18));
     text_layer_set_background_color(s_am_pm_layer, GColorClear);
-    text_layer_set_text_color(s_am_pm_layer, GColorWhite);
+    text_layer_set_text_color(s_am_pm_layer, config_foreground_color());
     text_layer_set_text(s_am_pm_layer, "PM");
     text_layer_set_text_alignment(s_am_pm_layer, GTextAlignmentLeft);
 
@@ -97,7 +97,8 @@ void time_layer_tick() {
 
 void time_layer_refresh() {
     text_layer_set_font(s_time_layer, config_time_font());
-    text_layer_set_text_color(s_time_layer, PBL_IF_COLOR_ELSE(g_config->color_time, GColorWhite));
+    text_layer_set_text_color(s_time_layer, config_time_color());
+    text_layer_set_text_color(s_am_pm_layer, config_foreground_color());
     time_layer_tick();  // Update main time text and layer positions
 }
 

--- a/src/c/layers/weather_status_layer.c
+++ b/src/c/layers/weather_status_layer.c
@@ -5,19 +5,19 @@
 
 #define FONT_18_OFFSET 7
 #define FONT_14_OFFSET 3
-#define CITY_INIT_WIDTH 100
+#define CONDITION_INIT_WIDTH 100
 #define MARGIN 2
 
 // emery: use larger text and arrow geometry
 #ifdef PBL_PLATFORM_EMERY
-#define CITY_FONT_KEY FONT_KEY_GOTHIC_18
+#define CONDITION_FONT_KEY FONT_KEY_GOTHIC_18
 #define SUN_EVENT_FONT_KEY FONT_KEY_GOTHIC_18
 #define ARROW_H 10
 #define ARROW_HEAD_H 4
 #define ARROW_HEAD_W 3
 #define ARROW_W 8
 #else
-#define CITY_FONT_KEY FONT_KEY_GOTHIC_14
+#define CONDITION_FONT_KEY FONT_KEY_GOTHIC_14
 #define SUN_EVENT_FONT_KEY FONT_KEY_GOTHIC_14
 #define ARROW_H 8
 #define ARROW_HEAD_H 3
@@ -29,7 +29,7 @@ static GRect frame_curr_temp;
 static GRect frame_sun_event;
 
 static Layer *s_weather_status_layer;
-static TextLayer *s_city_layer;
+static TextLayer *s_condition_layer;
 static TextLayer *s_current_temp_layer;
 static TextLayer *s_next_sun_event_layer;
 
@@ -51,19 +51,24 @@ static void text_layer_move_frame(TextLayer *text_layer, GRect frame) {
     layer_set_frame(text_layer_get_layer(text_layer), frame);
 }
 
-static void city_layer_refresh() {
-    // Set the city text layer contents from storage
-    static char s_city_buffer[20];
-    persist_get_city(s_city_buffer, sizeof(s_city_buffer));
-    text_layer_set_text(s_city_layer, s_city_buffer);
+static void condition_layer_refresh() {
+    static char s_status_text_buffer[32];
+    if (g_config->weather_status_condition) {
+        persist_get_condition(s_status_text_buffer, sizeof(s_status_text_buffer));
+        text_layer_set_overflow_mode(s_condition_layer, GTextOverflowModeFill);
+    } else {
+        persist_get_city(s_status_text_buffer, sizeof(s_status_text_buffer));
+        text_layer_set_overflow_mode(s_condition_layer, GTextOverflowModeTrailingEllipsis);
+    }
+    text_layer_set_text(s_condition_layer, s_status_text_buffer);
 
     // Dynamic resizing
     GRect bounds = layer_get_bounds(s_weather_status_layer);
-    GSize size = text_layer_get_content_size(s_city_layer);
+    GSize size = text_layer_get_content_size(s_condition_layer);
     int x = frame_curr_temp.origin.x + frame_curr_temp.size.w + MARGIN * 2;
     int y;
     int h;
-    // emery: align city text baseline with 18px font metrics instead of 14px metrics.
+    // emery: align condition text baseline with 18px font metrics instead of 14px metrics.
 #ifdef PBL_PLATFORM_EMERY
     y = -FONT_18_OFFSET;
     h = size.h + FONT_18_OFFSET;
@@ -72,7 +77,7 @@ static void city_layer_refresh() {
     h = size.h + FONT_14_OFFSET;
 #endif
     int w = bounds.size.w - frame_curr_temp.size.w - frame_sun_event.size.w - MARGIN * 4;
-    text_layer_move_frame(s_city_layer, GRect(x, y, w, h));
+    text_layer_move_frame(s_condition_layer, GRect(x, y, w, h));
 }
 
 static void current_temp_layer_refresh() {
@@ -117,33 +122,34 @@ static void sun_event_layer_refresh() {
 }
 
 static void weather_status_layer_init(GRect bounds) {
-    // Set up the city text layer properties
+    // Set up the weather status text layers.
     int w = bounds.size.w;
 
     // Current temperature
     s_current_temp_layer = text_layer_create(GRect(MARGIN, -FONT_18_OFFSET, 40, 25));
     text_layer_set_background_color(s_current_temp_layer, GColorClear);
     text_layer_set_text_alignment(s_current_temp_layer, GTextAlignmentLeft);
-    text_layer_set_text_color(s_current_temp_layer, GColorWhite);
+    text_layer_set_text_color(s_current_temp_layer, config_foreground_color());
     text_layer_set_font(s_current_temp_layer, fonts_get_system_font(FONT_KEY_GOTHIC_18));
 
-    // City where weather was fetched
-    s_city_layer = text_layer_create(GRect(w/2 - CITY_INIT_WIDTH/2, -FONT_14_OFFSET, CITY_INIT_WIDTH, 25));
-    text_layer_set_background_color(s_city_layer, GColorClear);
-    text_layer_set_text_alignment(s_city_layer, GTextAlignmentCenter);
-    text_layer_set_text_color(s_city_layer, GColorWhite);
-    text_layer_set_font(s_city_layer, fonts_get_system_font(CITY_FONT_KEY));
+    // Current weather condition
+    s_condition_layer = text_layer_create(GRect(w/2 - CONDITION_INIT_WIDTH/2, -FONT_14_OFFSET, CONDITION_INIT_WIDTH, 25));
+    text_layer_set_background_color(s_condition_layer, GColorClear);
+    text_layer_set_text_alignment(s_condition_layer, GTextAlignmentCenter);
+    text_layer_set_text_color(s_condition_layer, config_foreground_color());
+    text_layer_set_overflow_mode(s_condition_layer, GTextOverflowModeFill);
+    text_layer_set_font(s_condition_layer, fonts_get_system_font(CONDITION_FONT_KEY));
 
     // Time of next sun event (sunrise/sunset)
     s_next_sun_event_layer = text_layer_create(GRect(w - MARGIN - 6 - 40, 4 - FONT_18_OFFSET, 40, 25));
     text_layer_set_background_color(s_next_sun_event_layer, GColorClear);
     text_layer_set_text_alignment(s_next_sun_event_layer, GTextAlignmentLeft);
-    text_layer_set_text_color(s_next_sun_event_layer, GColorWhite);
+    text_layer_set_text_color(s_next_sun_event_layer, config_foreground_color());
     text_layer_set_font(s_next_sun_event_layer, fonts_get_system_font(SUN_EVENT_FONT_KEY));
 
     current_temp_layer_refresh();
     sun_event_layer_refresh();
-    city_layer_refresh();
+    condition_layer_refresh();
 }
 
 static void weather_status_update_proc(Layer *layer, GContext *ctx) {
@@ -166,9 +172,9 @@ static void weather_status_update_proc(Layer *layer, GContext *ctx) {
 #else
     gpath_move_to(s_arrow_path, GPoint(w - 4, 6));
 #endif
-    graphics_context_set_stroke_color(ctx, GColorWhite);
+    graphics_context_set_stroke_color(ctx, config_foreground_color());
     gpath_draw_outline_open(ctx, s_arrow_path);
-    graphics_context_set_fill_color(ctx, GColorWhite);
+    graphics_context_set_fill_color(ctx, config_foreground_color());
     gpath_draw_filled(ctx, s_arrow_path);
     MEMORY_LOG_HEAP("weather_status_update:exit");
 }
@@ -184,7 +190,7 @@ void weather_status_layer_create(Layer* parent_layer, GRect frame) {
 
     // Set up all the text layers
     weather_status_layer_init(bounds);
-    layer_add_child(s_weather_status_layer, text_layer_get_layer(s_city_layer));
+    layer_add_child(s_weather_status_layer, text_layer_get_layer(s_condition_layer));
     layer_add_child(s_weather_status_layer, text_layer_get_layer(s_current_temp_layer));
     layer_add_child(s_weather_status_layer, text_layer_get_layer(s_next_sun_event_layer));
     layer_set_update_proc(s_weather_status_layer, weather_status_update_proc);
@@ -196,15 +202,18 @@ void weather_status_layer_create(Layer* parent_layer, GRect frame) {
 
 void weather_status_layer_refresh() {
     layer_mark_dirty(s_weather_status_layer);
+    text_layer_set_text_color(s_current_temp_layer, config_foreground_color());
+    text_layer_set_text_color(s_condition_layer, config_foreground_color());
+    text_layer_set_text_color(s_next_sun_event_layer, config_foreground_color());
     current_temp_layer_refresh();
     sun_event_layer_refresh();
-    city_layer_refresh();
+    condition_layer_refresh();
     MEMORY_LOG_HEAP("after_weather_refresh");
 }
 
 void weather_status_layer_destroy() {
     MEMORY_LOG_HEAP("weather_status_layer_destroy:before");
-    text_layer_destroy(s_city_layer);
+    text_layer_destroy(s_condition_layer);
     text_layer_destroy(s_current_temp_layer);
     text_layer_destroy(s_next_sun_event_layer);
     if (s_arrow_path) {

--- a/src/c/windows/main_window.c
+++ b/src/c/windows/main_window.c
@@ -43,7 +43,7 @@ static void main_window_load(Window *window) {
     GRect bounds = layer_get_bounds(window_layer);
     int w = bounds.size.w;
     int h = bounds.size.h;
-    window_set_background_color(window, GColorBlack);
+    window_set_background_color(window, config_background_color());
 
 #ifdef PBL_PLATFORM_EMERY
     // emery: pad to avoid content getting obscured by screen edge
@@ -133,11 +133,13 @@ void main_window_create() {
 }
 
 void main_window_refresh() {
+    window_set_background_color(s_main_window, config_background_color());
     time_layer_refresh();
     weather_status_layer_refresh();
     forecast_layer_refresh();
     calendar_layer_refresh();
     calendar_status_layer_refresh();
+    loading_layer_refresh();
 }
 
 void main_window_destroy() {

--- a/src/pkjs/clay/config.js
+++ b/src/pkjs/clay/config.js
@@ -15,6 +15,31 @@ module.exports = [
         "items": [
             {
                 "type": "heading",
+                "defaultValue": "Appearance",
+            },
+            {
+                "type": "select",
+                "label": "Color scheme",
+                "messageKey": "appearance",
+                "defaultValue": "dark",
+                "options": [
+                    {
+                        "label": "Dark",
+                        "value": "dark"
+                    },
+                    {
+                        "label": "Light",
+                        "value": "light"
+                    }
+                ]
+            },
+        ]
+    },
+    {
+        "type": "section",
+        "items": [
+            {
+                "type": "heading",
                 "defaultValue": "Time",
             },
             {
@@ -169,6 +194,23 @@ module.exports = [
                     {
                         "label": "°C",
                         "value": "c"
+                    }
+                ]
+            },
+            {
+                "type": "select",
+                "label": "Status text",
+                "messageKey": "weatherStatusText",
+                "defaultValue": "condition",
+                "description": "Choose the text shown above the forecast graph.",
+                "options": [
+                    {
+                        "label": "Weather condition",
+                        "value": "condition"
+                    },
+                    {
+                        "label": "Location",
+                        "value": "location"
                     }
                 ]
             },

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -495,6 +495,8 @@ function sendClaySettings(onSuccess, onFailure) {
         "CLAY_COLOR_US_FEDERAL": app.settings.hasOwnProperty('colorUSFederal') ? app.settings.colorUSFederal : DEFAULT_COLOR_FOLLY,
         "CLAY_COLOR_TIME": app.settings.hasOwnProperty('colorTime') ? app.settings.colorTime : DEFAULT_COLOR_WHITE,
         "CLAY_DAY_NIGHT_SHADING": app.settings.hasOwnProperty('dayNightShading') ? app.settings.dayNightShading : true,
+        "CLAY_LIGHT_MODE": app.settings.appearance === 'light',
+        "CLAY_WEATHER_STATUS_CONDITION": app.settings.weatherStatusText === 'condition',
     }
     Pebble.sendAppMessage(payload, function() {
         console.log('Message sent successfully: ' + JSON.stringify(payload));
@@ -584,6 +586,8 @@ function getDefaultClaySettings() {
         fetch: false,
         location: '',
         temperatureUnits: 'f',
+        appearance: 'dark',
+        weatherStatusText: 'condition',
         dayNightShading: true,
         timeLeadingZero: false,
         timeShowAmPm: false,
@@ -822,6 +826,7 @@ function getFixtureWeatherPayload(fixture) {
     provider.id = 'fixture';
     provider.numEntries = Array.isArray(weather.temps) ? weather.temps.length : 0;
     provider.cityName = weather.city || 'Fixture City';
+    provider.condition = weather.condition || 'Unknown';
     provider.currentTemp = weather.currentTemp;
     provider.startTime = weather.startEpoch;
     provider.tempTrend = Array.isArray(weather.temps) ? weather.temps.slice(0) : [];

--- a/src/pkjs/weather/condition-label.js
+++ b/src/pkjs/weather/condition-label.js
@@ -1,0 +1,199 @@
+var WEATHER_COMPANY_LABELS = {
+    0: 'Tornado',
+    1: 'Tropical Storm',
+    2: 'Hurricane',
+    3: 'Severe Storm',
+    4: 'T-storms',
+    5: 'Wintry Mix',
+    6: 'Rain/Sleet',
+    7: 'Snow/Sleet',
+    8: 'Frz Drizzle',
+    9: 'Drizzle',
+    10: 'Frz Rain',
+    11: 'Showers',
+    12: 'Showers',
+    13: 'Flurries',
+    14: 'Snow Showers',
+    15: 'Blowing Snow',
+    16: 'Snow',
+    17: 'Hail',
+    18: 'Sleet',
+    19: 'Dust',
+    20: 'Fog',
+    21: 'Haze',
+    22: 'Smoke',
+    23: 'Blustery',
+    24: 'Windy',
+    25: 'Cold',
+    26: 'Cloudy',
+    27: 'Mostly Cloudy',
+    28: 'Mostly Cloudy',
+    29: 'Partly Cloudy',
+    30: 'Partly Cloudy',
+    31: 'Clear',
+    32: 'Sunny',
+    33: 'Fair',
+    34: 'Fair',
+    35: 'Rain/Hail',
+    36: 'Hot',
+    37: 'T-storms',
+    38: 'T-storms',
+    39: 'T-storms',
+    40: 'Showers',
+    41: 'Heavy Snow',
+    42: 'Snow Showers',
+    43: 'Heavy Snow',
+    44: 'Partly Cloudy',
+    45: 'T-showers',
+    46: 'Snow Showers',
+    47: 'T-showers'
+};
+
+/**
+ * Convert an OpenWeather condition object to a short watch label.
+ *
+ * @param {Object|null} weather OpenWeather current weather object.
+ * @returns {string} Short condition label.
+ */
+function fromOpenWeather(weather) {
+    var id = weather && Number(weather.id);
+
+    if (typeof id !== 'number' || !isFinite(id)) {
+        return fromPhrase(weather && (weather.description || weather.main));
+    }
+    if (id >= 200 && id <= 232) {
+        return 'T-storms';
+    }
+    if (id >= 300 && id <= 321) {
+        return 'Drizzle';
+    }
+    if (id === 500) {
+        return 'Light Rain';
+    }
+    if (id === 501) {
+        return 'Rain';
+    }
+    if (id >= 502 && id <= 504) {
+        return 'Heavy Rain';
+    }
+    if (id === 511) {
+        return 'Frz Rain';
+    }
+    if (id >= 520 && id <= 531) {
+        return 'Showers';
+    }
+    if (id === 600) {
+        return 'Light Snow';
+    }
+    if (id === 601) {
+        return 'Snow';
+    }
+    if (id === 602) {
+        return 'Heavy Snow';
+    }
+    if (id >= 611 && id <= 613) {
+        return 'Sleet';
+    }
+    if (id === 615 || id === 616) {
+        return 'Wintry Mix';
+    }
+    if (id >= 620 && id <= 622) {
+        return 'Snow Showers';
+    }
+
+    switch (id) {
+        case 701: return 'Mist';
+        case 711: return 'Smoke';
+        case 721: return 'Haze';
+        case 731: return 'Dust Whirls';
+        case 741: return 'Fog';
+        case 751: return 'Sand';
+        case 761: return 'Dust';
+        case 762: return 'Volcanic Ash';
+        case 771: return 'Squalls';
+        case 781: return 'Tornado';
+        case 800: return 'Clear';
+        case 801: return 'Few Clouds';
+        case 802: return 'Partly Cloudy';
+        case 803: return 'Mostly Cloudy';
+        case 804: return 'Overcast';
+        default: return fromPhrase(weather.description || weather.main);
+    }
+}
+
+/**
+ * Convert a Weather Company current observation to a short watch label.
+ *
+ * @param {Object|null} current Weather Company current observation.
+ * @returns {string} Short condition label.
+ */
+function fromWeatherCompany(current) {
+    var code = current && Number(current.iconCode);
+    var phraseLabel = fromPhrase(current && (current.wxPhraseShort || current.wxPhraseMedium || current.wxPhraseLong));
+
+    if (phraseLabel !== 'Unknown') {
+        return phraseLabel;
+    }
+    if (typeof code === 'number' && isFinite(code) && Object.prototype.hasOwnProperty.call(WEATHER_COMPANY_LABELS, code)) {
+        return WEATHER_COMPANY_LABELS[code];
+    }
+
+    return 'Unknown';
+}
+
+/**
+ * Reduce an unexpected provider phrase to the fixed short-label vocabulary.
+ *
+ * @param {*} phrase Provider condition phrase.
+ * @returns {string} Short condition label.
+ */
+function fromPhrase(phrase) {
+    var value = typeof phrase === 'string' ? phrase.toLowerCase() : '';
+
+    if (value.indexOf('tornado') !== -1) return 'Tornado';
+    if (value.indexOf('hurricane') !== -1) return 'Hurricane';
+    if (value.indexOf('tropical storm') !== -1) return 'Tropical Storm';
+    if (value.indexOf('thunder') !== -1 || value.indexOf('t-storm') !== -1) return 'T-storms';
+    if (value.indexOf('t-shower') !== -1) return 'T-showers';
+    if (value.indexOf('freezing drizzle') !== -1 || value.indexOf('frz drizzle') !== -1) return 'Frz Drizzle';
+    if (value.indexOf('freezing rain') !== -1 || value.indexOf('frz rain') !== -1) return 'Frz Rain';
+    if (value.indexOf('rain and snow') !== -1 || value.indexOf('rain/snow') !== -1 || value.indexOf('wintry') !== -1) return 'Wintry Mix';
+    if (value.indexOf('snow shower') !== -1) return 'Snow Showers';
+    if (value.indexOf('heavy snow') !== -1) return 'Heavy Snow';
+    if (value.indexOf('light snow') !== -1) return 'Light Snow';
+    if (value.indexOf('blowing snow') !== -1) return 'Blowing Snow';
+    if (value.indexOf('snow') !== -1) return 'Snow';
+    if (value.indexOf('sleet') !== -1) return 'Sleet';
+    if (value.indexOf('shower') !== -1) return 'Showers';
+    if (value.indexOf('drizzle') !== -1) return 'Drizzle';
+    if (value.indexOf('heavy rain') !== -1) return 'Heavy Rain';
+    if (value.indexOf('light rain') !== -1) return 'Light Rain';
+    if (value.indexOf('rain') !== -1) return 'Rain';
+    if (value.indexOf('mostly cloudy') !== -1 || value === 'm cloudy') return 'Mostly Cloudy';
+    if (value.indexOf('partly cloudy') !== -1 || value === 'p cloudy') return 'Partly Cloudy';
+    if (value.indexOf('few cloud') !== -1) return 'Few Clouds';
+    if (value.indexOf('overcast') !== -1) return 'Overcast';
+    if (value.indexOf('cloud') !== -1) return 'Cloudy';
+    if (value.indexOf('clear') !== -1) return 'Clear';
+    if (value.indexOf('sunny') !== -1) return 'Sunny';
+    if (value.indexOf('fair') !== -1) return 'Fair';
+    if (value.indexOf('fog') !== -1) return 'Fog';
+    if (value.indexOf('mist') !== -1) return 'Mist';
+    if (value.indexOf('haze') !== -1) return 'Haze';
+    if (value.indexOf('smoke') !== -1) return 'Smoke';
+    if (value.indexOf('dust') !== -1) return 'Dust';
+    if (value.indexOf('sand') !== -1) return 'Sand';
+    if (value.indexOf('ash') !== -1) return 'Volcanic Ash';
+    if (value.indexOf('squall') !== -1) return 'Squalls';
+    if (value.indexOf('hail') !== -1) return 'Hail';
+    if (value.indexOf('wind') !== -1) return 'Windy';
+    if (value.indexOf('cold') !== -1) return 'Cold';
+    if (value.indexOf('hot') !== -1) return 'Hot';
+
+    return 'Unknown';
+}
+
+module.exports = {
+    fromOpenWeather: fromOpenWeather,
+    fromWeatherCompany: fromWeatherCompany
+};

--- a/src/pkjs/weather/openweathermap.js
+++ b/src/pkjs/weather/openweathermap.js
@@ -1,4 +1,5 @@
 var WeatherProvider = require('./provider.js');
+var conditionLabel = require('./condition-label.js');
 var request = WeatherProvider.request;
 
 var OpenWeatherMapProvider = function(apiKey) {
@@ -102,6 +103,8 @@ OpenWeatherMapProvider.prototype.withProviderData = function(lat, lon, force, on
         });
         this.startTime = weatherData.hourly[0].dt;
         this.currentTemp = weatherData.current.temp;
+        var currentWeather = Array.isArray(weatherData.current.weather) ? weatherData.current.weather[0] : null;
+        this.condition = conditionLabel.fromOpenWeather(currentWeather);
         onSuccess();
     }).bind(this), onFailure);
 };

--- a/src/pkjs/weather/provider.js
+++ b/src/pkjs/weather/provider.js
@@ -607,6 +607,9 @@ WeatherProvider.prototype.getPayload = function() {
         NUM_ENTRIES: this.numEntries,
         CURRENT_TEMP: Math.round(this.currentTemp),
         CITY: this.cityName,
+        CONDITION: typeof this.condition === 'string' && this.condition.trim() !== ''
+            ? this.condition.trim().slice(0, 31)
+            : 'Unknown',
         // The first byte determines whether the list of events starts on a sunrise (0) or sunset (1)
         SUN_EVENTS: [this.sunEvents[0].type === 'sunrise' ? 0 : 1].concat(sunEventsByteArray)
     };

--- a/src/pkjs/weather/wunderground.js
+++ b/src/pkjs/weather/wunderground.js
@@ -1,4 +1,5 @@
 var WeatherProvider = require('./provider.js');
+var conditionLabel = require('./condition-label.js');
 var request = WeatherProvider.request;
 
 var WundergroundProvider = function() {
@@ -69,7 +70,7 @@ WundergroundProvider.prototype.withWundergroundCurrent = function(lat, lon, apiK
                 return;
             }
 
-            callback(weatherData.temperature);
+            callback(weatherData);
         }).bind(this),
         function(error) {
             onFailure({ stage: 'provider_data', code: 'wu_current_' + error.code });
@@ -129,7 +130,7 @@ WundergroundProvider.prototype.withProviderData = function(lat, lon, force, onSu
     }
 
     this.withApiKey((function(apiKey) {
-        this.withWundergroundCurrent(lat, lon, apiKey, (function(currentTemp) {
+        this.withWundergroundCurrent(lat, lon, apiKey, (function(current) {
             this.withWundergroundForecast(lat, lon, apiKey, (function(forecast) {
                 this.tempTrend = forecast.map(function(entry) {
                     return entry.temp;
@@ -138,7 +139,8 @@ WundergroundProvider.prototype.withProviderData = function(lat, lon, force, onSu
                     return entry.pop / 100.0;
                 });
                 this.startTime = forecast[0].fcst_valid;
-                this.currentTemp = currentTemp;
+                this.currentTemp = current.temperature;
+                this.condition = conditionLabel.fromWeatherCompany(current);
                 onSuccess();
             }).bind(this), onFailure);
         }).bind(this), onFailure);


### PR DESCRIPTION
## Summary

- add configurable light and dark appearances across the watchface
- show a normalized current weather condition above the graph, while keeping forecast location as a configuration option
- show a numeric battery percentage beside the compact battery icon on Pebble Time 2 (Emery); smaller displays retain the compact icon only
- add deterministic light-theme fixture coverage and document the new options

## Testing

- `mise build`
- `mise build release`
- both profiles build successfully for Aplite, Basalt, Diorite, Emery, and Flint
- visually checked light mode on Aplite, Basalt, and Emery
- visually checked condition and location status modes on Emery
- verified condition mappings and fixture JSON
- `git diff --check`
